### PR TITLE
fix generated code for SimpleButton

### DIFF
--- a/format/swf/instance/Bitmap.hx
+++ b/format/swf/instance/Bitmap.hx
@@ -120,11 +120,13 @@ class Bitmap extends flash.display.Bitmap {
 				#if ((cpp || neko) && openfl_legacy)
 				bitmapData.setPixels (bitmapData.rect, buffer);
 				bitmapData.unmultiplyAlpha ();
-				#else
+				#elseif !flash
 				bitmapData.image.buffer.premultiplied = false;
 				bitmapData.setPixels (bitmapData.rect, buffer);
 				bitmapData.image.buffer.premultiplied = true;
 				bitmapData.image.premultiplied = false;
+				#else
+				bitmapData.setPixels (bitmapData.rect, buffer);
 				#end
 				
 				data.instance = bitmapData;

--- a/templates/swf/SimpleButton.mtt
+++ b/templates/swf/SimpleButton.mtt
@@ -20,7 +20,7 @@ class ::CLASS_NAME:: extends SimpleButton {
 		var swf = SWF.instances.get ("::SWF_ID::");
 		var symbol = swf.data.getCharacter (::SYMBOL_ID::);
 		
-		super (cast symbol);
+		super (swf.data,cast symbol);
 		
 	}
 	


### PR DESCRIPTION
Hi,

I made a simple change in the SimpleButton template to fix generated code.
Tested with flash , windows and html5 target. 

Works with flash.

Doesn't compile with html5 : 
```
Type not found : ButtonNext
```
Compile with windows target but a runtime exception is thrown :
```
invalid cast 
format.swf.instance.SimpleButton::new format/swf/instance/SimpleButton.hx line 54
ButtonNext::new ButtonNext.hx line 23
```
Generated class :
```
import format.swf.instance.SimpleButton;
import format.SWF;
import openfl.Assets;


class ButtonNext extends SimpleButton {
	
	
	public function new () {
		
		if (!SWF.instances.exists ("libraries/main/main.swf")) {
			
			SWF.instances.set ("libraries/main/main.swf", new SWF (Assets.getBytes ("libraries/main/main.swf")));
			
		}
		
		var swf = SWF.instances.get ("libraries/main/main.swf");
		var symbol = swf.data.getCharacter (389);
		
		super (swf.data,cast symbol);
		
	}
	
	
}
```

Cast error is on the super call.