### PR TITLE
swflite textfield bugfix

### DIFF
--- a/format/swf/lite/DynamicTextField.hx
+++ b/format/swf/lite/DynamicTextField.hx
@@ -122,7 +122,7 @@ class DynamicTextField extends TextField {
 			
 			htmlText = symbol.text;
 			
-		} else {
+		} else #if (flash) if (symbol.text != null) #end {
 			
 			text = symbol.text;
 			


### PR DESCRIPTION
flash throws an error if you try assigning null to TextFIeld.text property