### PR TITLE
fixes #68 "Enum not found with OpenFl 3.6.0"

### DIFF
--- a/format/swf/lite/SWFLite.hx
+++ b/format/swf/lite/SWFLite.hx
@@ -169,6 +169,7 @@ import openfl.Assets;
 		
 		var serializer = new Serializer ();
 		serializer.useCache = true;
+		serializer.useEnumIndex = true;
 		serializer.serialize (this);
 		return serializer.toString ();
 		

--- a/format/swf/lite/SWFLite.hx
+++ b/format/swf/lite/SWFLite.hx
@@ -165,11 +165,11 @@ import openfl.Assets;
 	}
 	
 	
-	public function serialize ():String {
+	public function serialize (useEnumIndex:Bool):String {
 		
 		var serializer = new Serializer ();
 		serializer.useCache = true;
-		serializer.useEnumIndex = true;
+		serializer.useEnumIndex = useEnumIndex;
 		serializer.serialize (this);
 		return serializer.toString ();
 		

--- a/tools/Tools.hx
+++ b/tools/Tools.hx
@@ -728,7 +728,7 @@ class Tools {
 					//}
 					
 					var swfLiteAsset = new Asset ("", "lib/" + library.name + "/" + library.name + ".dat", AssetType.TEXT);
-					var swfLiteAssetData = swfLite.serialize ();
+					var swfLiteAssetData = swfLite.serialize (project.target != Platform.FLASH);
 					
 					if (cacheDirectory != null) {
 						


### PR DESCRIPTION
In 3.6.0 enums like GradientType, SpreadMethod etc. were refactored into Enum abstracts, which means the Enum classes don't exist at runtime, hence we have to use indexes when serializing for SWFLite.