### PR TITLE
removed additional leading

### DIFF
--- a/format/swf/lite/DynamicTextField.hx
+++ b/format/swf/lite/DynamicTextField.hx
@@ -102,9 +102,6 @@ class DynamicTextField extends TextField {
 			format.rightMargin = Std.int (symbol.rightMargin / 20);
 			format.indent = Std.int (symbol.indent / 20);
 			format.leading = Std.int (symbol.leading / 20);
-			
-			if (embedFonts) format.leading += 4; // TODO: Why is this necessary?
-			
 		}
 		
 		defaultTextFormat = format;


### PR DESCRIPTION
I don't know why it was necessary but it seems to works without it. Also it fixes the aspect of textfields in html5 by removing the additional leading value.