### PR TITLE
Fix for EditText when font class is specified but not font name.

### DIFF
--- a/format/swf/tags/TagDefineEditText.hx
+++ b/format/swf/tags/TagDefineEditText.hx
@@ -82,7 +82,7 @@ class TagDefineEditText implements IDefinitionTag
 		if (hasFontClass) {
 			fontClass = data.readSTRING();
 		}
-		if (hasFont) {
+		if (hasFont || hasFontClass) {
 			fontHeight = data.readUI16();
 		}
 		if (hasTextColor) {
@@ -134,7 +134,7 @@ class TagDefineEditText implements IDefinitionTag
 		if (hasFontClass) {
 			body.writeSTRING(fontClass);
 		}
-		if (hasFont) {
+		if (hasFont || hasFontClass) {
 			body.writeUI16(fontHeight);
 		}
 		if (hasTextColor) {


### PR DESCRIPTION
This pull request is to address an issue we've seen when loading .swf files which specify FontClass  but not Font Name in EditText elements.

We've been using the Adobe SWF Investigator as 'ground truth' for swf parsing (https://sourceforge.net/adobe/swfinvestigator/code/HEAD/tree/) and in that light these changes seem to be justified.

I've put together a small test application which reproduces the issue and tests the fix at https://github.com/johnoneil/swf. Use as follows:

Launch the haxe htlm5 swf load test (using current swf release)
`05787b-joneil:example joneil$ make
rm -fr Export
#making swf lib in submodule.
cd swf/tools && haxe build.hxml
/usr/local/lib/haxe/lib/swf/2,2,0/format/swf/SWFTimelineContainer.hx:206: characters 49-64 : format.swf.data.SWFRawTag has no field toString
make: *** [swflib] Error 1
`

Use the local submodule with swf fix in place:
`
05787b-joneil:example joneil$ make set-swf
haxelib dev swf swf
Development directory set to /Users/joneil/zynga/haxe/swf_bug/example/swf
05787b-joneil:example joneil$ make
rm -fr Export
#making swf lib in submodule.
cd swf/tools && haxe build.hxml
openfl test html5
`

With the fix in place we load the .swf properly.
