### PR TITLE
Reset name, filters and color-transforms between frames.

### DIFF
--- a/format/swf/lite/MovieClip.hx
+++ b/format/swf/lite/MovieClip.hx
@@ -45,6 +45,9 @@ import lime.Assets in LimeAssets;
 class MovieClip extends flash.display.MovieClip {
 	
 	
+	@:noCompletion static private var __noColorTranform = new openfl.geom.ColorTransform();
+	
+	
 	@:noCompletion private var __frameTime:Int;
 	@:noCompletion private var __lastUpdate:Int;
 	@:noCompletion private var __objects:Map<Int, DisplayObject>;
@@ -567,11 +570,7 @@ class MovieClip extends flash.display.MovieClip {
 	
 	@:noCompletion private function __placeObject (displayObject:DisplayObject, frameObject:FrameObject):Void {
 		
-		if (frameObject.name != null) {
-			
-			displayObject.name = frameObject.name;
-			
-		}
+		displayObject.name = (frameObject.name != null)? frameObject.name : "";
 		
 		if (frameObject.matrix != null) {
 			
@@ -590,15 +589,11 @@ class MovieClip extends flash.display.MovieClip {
 			
 		}
 		
-		if (frameObject.colorTransform != null) {
+		displayObject.transform.colorTransform = (frameObject.colorTransform != null) ? frameObject.colorTransform : __noColorTranform;
 			
-			displayObject.transform.colorTransform = frameObject.colorTransform;
-			
-		}
+		var filters:Array<BitmapFilter> = [];
 		
 		if (frameObject.filters != null) {
-			
-			var filters:Array<BitmapFilter> = [];
 			
 			for (filter in frameObject.filters) {
 				
@@ -624,9 +619,9 @@ class MovieClip extends flash.display.MovieClip {
 				
 			}
 			
-			displayObject.filters = filters;
-			
 		}
+		
+		displayObject.filters = filters;
 		
 		Reflect.setField (this, displayObject.name, displayObject);
 		


### PR DESCRIPTION
Before this patch, when a filter or transform is applied in frame 2 (and none are in frame 1)
 the filter or transform would not be removed when going back to frame 1.

Especially noticeable in the Flash target where filters and color-transforms are actually working.