### PR TITLE
Bitmap renders

### DIFF
--- a/format/swf/exporters/SWFLiteExporter.hx
+++ b/format/swf/exporters/SWFLiteExporter.hx
@@ -426,34 +426,40 @@ class SWFLiteExporter {
 			
 		}
 		
+		//check if we can replace this shape with a series of bitmaps (see ShapeBitmapExporter for reasoning)
 		var bitmaps = ShapeBitmapExporter.process(handler);
-		if(bitmaps != null){
+		
+		if(bitmaps != null) {
 			
+			//if we can, construct a sprite and add all the bitmaps to this sprite as children
+			//this will preserve the correct .numChildren and .addChildAt behavior the shape has
 			var spriteSymbol = new SpriteSymbol ();
 			var frame = new Frame();
-			for(i in 0...bitmaps.length){
+			
+			for(i in 0...bitmaps.length) {
+				
+				//construct the bitmap and add it to the sprite
 				var bitmap = bitmaps[i];
-				var transform = bitmap.transform;
-				// transform.tx *= (1 / 20);
-				// transform.ty *= (1 / 20);
 				var frameObject = new FrameObject ();
 				frameObject.symbol = bitmap.id;
 				frameObject.id = i;	
 				frameObject.depth = i;
-				frameObject.matrix = transform;
+				frameObject.matrix = bitmap.transform;
 				frame.objects.push (frameObject);
+				
 			}
 			
+			//finish constructing the sprite and save it
 			spriteSymbol.frames.push (frame);
 			spriteSymbol.id = tag.characterId;
 			swfLite.symbols.set (spriteSymbol.id, spriteSymbol);
 			return spriteSymbol;
+			
+		} else {
+			
+			swfLite.symbols.set (symbol.id, symbol);
+			return symbol;
 		}
-		
-		swfLite.symbols.set (symbol.id, symbol);
-		
-		return symbol;
-		
 	}
 	
 	

--- a/format/swf/exporters/SWFLiteExporter.hx
+++ b/format/swf/exporters/SWFLiteExporter.hx
@@ -402,7 +402,7 @@ class SWFLiteExporter {
 	}
 	
 	
-	private function addShape (tag:TagDefineShape):ShapeSymbol {
+	private function addShape (tag:TagDefineShape):SWFSymbol {
 		
 		var symbol = new ShapeSymbol ();
 		symbol.id = tag.characterId;
@@ -424,6 +424,30 @@ class SWFLiteExporter {
 				
 			}
 			
+		}
+		
+		var bitmaps = ShapeBitmapExporter.process(handler);
+		if(bitmaps != null){
+			
+			var spriteSymbol = new SpriteSymbol ();
+			var frame = new Frame();
+			for(i in 0...bitmaps.length){
+				var bitmap = bitmaps[i];
+				var transform = bitmap.transform;
+				// transform.tx *= (1 / 20);
+				// transform.ty *= (1 / 20);
+				var frameObject = new FrameObject ();
+				frameObject.symbol = bitmap.id;
+				frameObject.id = i;	
+				frameObject.depth = i;
+				frameObject.matrix = transform;
+				frame.objects.push (frameObject);
+			}
+			
+			spriteSymbol.frames.push (frame);
+			spriteSymbol.id = tag.characterId;
+			swfLite.symbols.set (spriteSymbol.id, spriteSymbol);
+			return spriteSymbol;
 		}
 		
 		swfLite.symbols.set (symbol.id, symbol);

--- a/format/swf/exporters/ShapeBitmapExporter.hx
+++ b/format/swf/exporters/ShapeBitmapExporter.hx
@@ -1,0 +1,56 @@
+package format.swf.exporters;
+
+import haxe.ds.Option;
+
+import format.swf.exporters.core.ShapeCommand;
+import openfl.geom.Matrix;
+
+class ShapeBitmapExporter
+{
+    
+    public static function process(exporter:ShapeCommandExporter):Array<{id:Int, transform:Matrix}> {
+        var bitmaps = [];
+        var commands = exporter.commands.copy();
+        var eligable = commands != null && commands.length > 0 && commands.length % 9 == 0;
+        if(!eligable) return null;
+        
+        while(commands.length > 0){
+            switch(processNextBitmap(commands.splice(0, 9))){
+                case Some(bitmap) : bitmaps.push(bitmap);
+                case None : return null;
+            }
+        }
+        return bitmaps;
+    }
+    
+    private static function processNextBitmap(commands:Array<ShapeCommand>):Option<{id:Int, transform:Matrix}> {
+        if(commands.length != 9) return null;
+        
+        var valid = true;
+        var bitmapId:Int = 0;
+        var vertices:Array<{x:Float, y:Float}> = [];
+        var localMatrix:Matrix = new Matrix();
+        localMatrix.identity();
+        var positionX = 0.0;
+        var positionY = 0.0;
+        var index = 0;
+        
+        for(command in commands){
+            switch(command){
+                case LineStyle(null, null, null, null, null, null, null, null) if(index == 0) : null;
+                case EndFill if (index == 1 || index == 8) : null;
+                case BeginBitmapFill(bid, matrix, repeat, smooth) if (index == 2) : 
+                    bitmapId = bid;
+                    if(matrix != null) localMatrix = matrix;
+                case MoveTo(x, y) if(index == 3) : 
+                    positionX = x;
+                    positionY = y;
+                case LineTo(x, y) if(index > 3 && index < 8) : vertices.push({x:x, y:y});
+                case EndFill if (index == 8) : null;
+                default : return None;
+            }
+            index++;
+        }
+        return Some({id:bitmapId, transform:localMatrix});	
+    }
+}

--- a/format/swf/exporters/ShapeBitmapExporter.hx
+++ b/format/swf/exporters/ShapeBitmapExporter.hx
@@ -5,52 +5,97 @@ import haxe.ds.Option;
 import format.swf.exporters.core.ShapeCommand;
 import openfl.geom.Matrix;
 
+
+/*
+* When you export a swf from flash, it saves all bitmap draws as Shapes, with a graphics that has one or more BeginBitmapFills.
+* swf does NOT add bitmap symbols to the stage, as you could expect.
+* This is inneficient in openfl, since it uses Cairo (software) to draw all graphics commands, meaning that all
+* swf bitmaps will be rendered using software. This is obviously very slow.
+*
+* ShapeBitmapExporter fixes this, by parsing graphics commands into distinct bitmap draws. 
+* These are then replaced with Bitmap instances in swf lite and rendered using hardware.
+*
+* ShapeBitmapExporter ONLY works if the graphics calls specifically draw bitmaps in the format specified by the SWF.
+* Any other format will not return any BitmapFills and will be rendered by software in Cairo.
+*/
+
+typedef BitmapFill = {
+    id:Int, 
+    transform:Matrix
+}
+
 class ShapeBitmapExporter
 {
     
-    public static function process(exporter:ShapeCommandExporter):Array<{id:Int, transform:Matrix}> {
+    public static function process(exporter:ShapeCommandExporter):Array<BitmapFill> 
+    {
         var bitmaps = [];
         var commands = exporter.commands.copy();
         var eligable = commands != null && commands.length > 0 && commands.length % 9 == 0;
-        if(!eligable) return null;
+        
+        if(!eligable) {
+            
+            return null;    
+            
+        } 
         
         while(commands.length > 0){
+            
             switch(processNextBitmap(commands.splice(0, 9))){
+                
                 case Some(bitmap) : bitmaps.push(bitmap);
                 case None : return null;
+                
             }
+            
         }
+        
         return bitmaps;
     }
     
-    private static function processNextBitmap(commands:Array<ShapeCommand>):Option<{id:Int, transform:Matrix}> {
-        if(commands.length != 9) return null;
-        
-        var valid = true;
+    //process a single bitmap from a series of graphics commands
+    private static function processNextBitmap(commands:Array<ShapeCommand>):Option<BitmapFill> 
+    {
+        var index = 0;
         var bitmapId:Int = 0;
-        var vertices:Array<{x:Float, y:Float}> = [];
-        var localMatrix:Matrix = new Matrix();
-        localMatrix.identity();
         var positionX = 0.0;
         var positionY = 0.0;
-        var index = 0;
+        var transform:Matrix = null;
         
-        for(command in commands){
-            switch(command){
+        //ensure the commands are in the order specified by the swf format, and parse out the bitmap details
+        for(command in commands) {
+            
+            switch(command) {
+                
                 case LineStyle(null, null, null, null, null, null, null, null) if(index == 0) : null;
-                case EndFill if (index == 1 || index == 8) : null;
-                case BeginBitmapFill(bid, matrix, repeat, smooth) if (index == 2) : 
+                case EndFill if (index == 1) : null;
+                case BeginBitmapFill(bid, matrix, repeat, smooth) if(index == 2) : 
                     bitmapId = bid;
-                    if(matrix != null) localMatrix = matrix;
+                    transform = matrix;
                 case MoveTo(x, y) if(index == 3) : 
                     positionX = x;
                     positionY = y;
-                case LineTo(x, y) if(index > 3 && index < 8) : vertices.push({x:x, y:y});
+                case LineTo(x, y) if(index == 4) : null;
+                case LineTo(x, y) if(index == 5) : null;
+                case LineTo(x, y) if(index == 6) : null;
+                case LineTo(x, y) if(index == 7) : null;
                 case EndFill if (index == 8) : null;
-                default : return None;
+                default : return None; //does not match the format
+                
             }
+            
             index++;
+            
         }
-        return Some({id:bitmapId, transform:localMatrix});	
+        
+        //default transform if none was supplied
+        if(transform == null) {
+            
+            transform = new Matrix();
+            transform.identity();
+            
+        }
+        
+        return Some({id:bitmapId, transform:transform});	
     }
 }


### PR DESCRIPTION
Optimizes the swf library by ensuring that bitmaps are rendered using hardware.

Without this change, performance is sluggish and rendering goes through Cairo, which leads to unexpected render results. 

It does this by checking if certain Shapes are actually just a collection of BitmapDraws on the graphics objects. If so, it replaces that shape with a sprite, and adds regular bitmaps to the sprite.

This preserves the .numChildren and .addChildAt properties.