### PR TITLE
Fixing issue with transform precision.

### DIFF
--- a/src/swf/exporters/animate/AnimateLibrary.hx
+++ b/src/swf/exporters/animate/AnimateLibrary.hx
@@ -574,9 +574,9 @@ import openfl.filters.GlowFilter;
 		return symbol;
 	}
 
-	private function __parseMatrix(values:Array<Int>):Matrix
+	private function __parseMatrix(values:Array<Float>):Matrix
 	{
-		return values != null ? new Matrix(values[0], values[1], values[2], values[3], __pixel(values[4]), __pixel(values[5])) : null;
+		return values != null ? new Matrix(values[0], values[1], values[2], values[3], __pixel(Std.int(values[4])), __pixel(Std.int(values[5]))) : null;
 	}
 
 	private function __parseShape(data:Dynamic):AnimateShapeSymbol


### PR DESCRIPTION
Fixing issue with transform matrix precision, when read the values was using ints instead of float, and as a result  X and Y scale value was truncated.

here's how one of my assets looked in data.json.

```
    "matrix": [
                1,
                0,
                0,
                0.999969482421875,
                15928,
                8857
              ]
```
As you can see Y scale is almost 1 but  a bit off (not sure why but that's a Flash IDE problem i guess)
and this is how it was after being read and used in a openFL project.
```
a:1
b:0
c:0
d:0
tx:796.4
ty:442.85
__array:null
```
as you can see the Y scale (d) is truncated to 0 and the asset was not visible at all.
