### PR TITLE
Move instances map init to static context

### DIFF
--- a/src/swf/exporters/animate/AnimateLibrary.hx
+++ b/src/swf/exporters/animate/AnimateLibrary.hx
@@ -49,7 +49,7 @@ import openfl.filters.GlowFilter;
 	];
 	#end
 
-	private static var instances:Map<String, AnimateLibrary>;
+	private static var instances:Map<String, AnimateLibrary> = new Map();
 
 	private var alphaCheck:Map<String, Bool>;
 	private var bitmapClassNames:Map<String, String>;
@@ -81,7 +81,6 @@ import openfl.filters.GlowFilter;
 		rootPath = "";
 		#end
 
-		if (instances == null) instances = new Map();
 		instances.set(uuid, this);
 
 		// Hack to include filter classes, macro.include is not working properly
@@ -113,7 +112,6 @@ import openfl.filters.GlowFilter;
 
 	private static function get(uuid:String):AnimateLibrary
 	{
-		if (instances == null) return null;
 		return instances.get(uuid);
 	}
 


### PR DESCRIPTION
AnimateLibrary - Move instances map init to static context so that it's always ready. Remove null check from get function.

I'm having an issue loading a swf asset and stumbled upon this messy code. Hope it wasn't like this to solve some problem.