### PR TITLE
openfl dev compatibility fixes

### DIFF
--- a/src/swf/SWF.hx
+++ b/src/swf/SWF.hx
@@ -109,11 +109,10 @@ class SWF extends EventDispatcher
 			symbol = data.getCharacter(charId);
 		}
 
-		// if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (symbol, TagDefineButton2)) {
-
-		// 	return new SimpleButton (data, cast symbol);
-
-		// }
+		if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (symbol, TagDefineButton2))
+		{
+			return new swf.runtime.SimpleButton(data, cast symbol);
+		}
 
 		return null;
 	}
@@ -143,11 +142,10 @@ class SWF extends EventDispatcher
 			}
 		}
 
-		// if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (symbol, SWFTimelineContainer)) {
-
-		// 	return new MovieClip (cast symbol);
-
-		// }
+		if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (symbol, SWFTimelineContainer))
+		{
+			return new swf.runtime.MovieClip(cast symbol);
+		}
 
 		return null;
 	}

--- a/src/swf/exporters/SWFLiteExporter.hx
+++ b/src/swf/exporters/SWFLiteExporter.hx
@@ -1,7 +1,6 @@
 package swf.exporters;
 
 import openfl.display.BitmapData;
-import openfl.geom.Matrix;
 import openfl.text.TextFormatAlign;
 import openfl.utils.ByteArray;
 import format.png.Data;

--- a/src/swf/exporters/SWFLiteExporter.hx
+++ b/src/swf/exporters/SWFLiteExporter.hx
@@ -136,8 +136,8 @@ class SWFLiteExporter
 					if (object.placeMatrix != null)
 					{
 						var matrix = object.placeMatrix.matrix;
-						matrix.tx *= (1 / 20);
-						matrix.ty *= (1 / 20);
+						matrix.tx = object.placeMatrix.translateX / 20;
+						matrix.ty = object.placeMatrix.translateY / 20;
 
 						frameObject.matrix = matrix;
 					}

--- a/src/swf/exporters/SWFLiteExporter.hx
+++ b/src/swf/exporters/SWFLiteExporter.hx
@@ -1,6 +1,7 @@
 package swf.exporters;
 
 import openfl.display.BitmapData;
+import openfl.geom.Matrix;
 import openfl.text.TextFormatAlign;
 import openfl.utils.ByteArray;
 import format.png.Data;
@@ -555,7 +556,9 @@ class SWFLiteExporter
 
 				if (placeTag.matrix != null)
 				{
-					var matrix = placeTag.matrix.matrix;
+					var matrix = new Matrix();
+					matrix.copyFrom(placeTag.matrix.matrix);
+					
 					matrix.tx *= (1 / 20);
 					matrix.ty *= (1 / 20);
 
@@ -807,7 +810,8 @@ class SWFLiteExporter
 
 		symbol.records = records;
 
-		var matrix = tag.textMatrix.matrix;
+		var matrix = new Matrix();
+		matrix.copyFrom(tag.textMatrix.matrix);
 		matrix.tx *= (1 / 20);
 		matrix.ty *= (1 / 20);
 

--- a/src/swf/exporters/SWFLiteExporter.hx
+++ b/src/swf/exporters/SWFLiteExporter.hx
@@ -556,11 +556,9 @@ class SWFLiteExporter
 
 				if (placeTag.matrix != null)
 				{
-					var matrix = new Matrix();
-					matrix.copyFrom(placeTag.matrix.matrix);
-					
-					matrix.tx *= (1 / 20);
-					matrix.ty *= (1 / 20);
+					var matrix = placeTag.matrix.matrix;
+					matrix.tx = placeTag.matrix.translateX / 20;
+					matrix.ty = placeTag.matrix.translateY / 20;
 
 					frameObject.matrix = matrix;
 				}
@@ -809,11 +807,10 @@ class SWFLiteExporter
 		}
 
 		symbol.records = records;
-
-		var matrix = new Matrix();
-		matrix.copyFrom(tag.textMatrix.matrix);
-		matrix.tx *= (1 / 20);
-		matrix.ty *= (1 / 20);
+		
+		var matrix = tag.textMatrix.matrix;
+		matrix.tx = tag.textMatrix.translateX / 20;
+		matrix.ty = tag.textMatrix.translateY / 20;
 
 		symbol.matrix = matrix;
 

--- a/src/swf/exporters/swflite/SpriteSymbol.hx
+++ b/src/swf/exporters/swflite/SpriteSymbol.hx
@@ -7,6 +7,8 @@ import openfl.display.DisplayObject;
 import openfl.display.MovieClip;
 import openfl.geom.Rectangle;
 
+import #if (haxe_ver >= 4.2) Std.isOfType #else Std.is as isOfType #end;
+
 #if !openfl_debug
 @:fileXml('tags="haxe,release"')
 @:noDebug
@@ -97,7 +99,7 @@ class SpriteSymbol extends SWFSymbol
 		}
 
 		#if flash
-		if (!#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (movieClip, flash.display.MovieClip.MovieClip2))
+		if (!isOfType(movieClip, flash.display.MovieClip.MovieClip2))
 		{
 			movieClip.scale9Grid = scale9Grid;
 		}

--- a/src/swf/exporters/swflite/SpriteSymbol.hx
+++ b/src/swf/exporters/swflite/SpriteSymbol.hx
@@ -5,6 +5,7 @@ import swf.exporters.swflite.timeline.Frame;
 import swf.exporters.swflite.timeline.SymbolTimeline;
 import openfl.display.DisplayObject;
 import openfl.display.MovieClip;
+import openfl.display.Sprite;
 import openfl.geom.Rectangle;
 
 import #if (haxe_ver >= 4.2) Std.isOfType #else Std.is as isOfType #end;
@@ -13,7 +14,6 @@ import #if (haxe_ver >= 4.2) Std.isOfType #else Std.is as isOfType #end;
 @:fileXml('tags="haxe,release"')
 @:noDebug
 #end
-@:access(openfl.display.MovieClip)
 class SpriteSymbol extends SWFSymbol
 {
 	public var baseClassName:String;
@@ -29,7 +29,15 @@ class SpriteSymbol extends SWFSymbol
 		frames = new Array<Frame>();
 	}
 
-	private function __constructor(movieClip:MovieClip):Void
+	private function __spriteConstructor(sprite:Sprite):Void
+	{
+		if (!isOfType(sprite, MovieClip))
+			throw "expected movieclip";
+		
+		__movieClipConstructor(cast sprite);
+	}
+
+	private function __movieClipConstructor(movieClip:MovieClip):Void
 	{
 		var timeline = new SymbolTimeline(swf, this);
 		#if flash
@@ -40,11 +48,21 @@ class SpriteSymbol extends SWFSymbol
 		movieClip.scale9Grid = scale9Grid;
 	}
 
-	private override function __createObject(swf:SWFLite):MovieClip
+	private inline function __setConstructor()
 	{
 		#if (!macro && !flash)
-		MovieClip.__constructor = __constructor;
+			@:privateAccess
+			#if (openfl <= "9.1.0")
+			MovieClip.__constructor = __movieClipConstructor;
+			#else
+			Sprite.__constructor = __spriteConstructor;
+			#end
 		#end
+	}
+
+	private override function __createObject(swf:SWFLite):MovieClip
+	{
+		__setConstructor();
 		this.swf = swf;
 
 		#if flash
@@ -110,15 +128,13 @@ class SpriteSymbol extends SWFSymbol
 
 	private override function __init(swf:SWFLite):Void
 	{
-		#if (!macro && !flash)
-		MovieClip.__constructor = __constructor;
-		#end
+		__setConstructor();
 		this.swf = swf;
 	}
 
 	private override function __initObject(swf:SWFLite, instance:DisplayObject):Void
 	{
 		this.swf = swf;
-		__constructor(cast instance);
+		__movieClipConstructor(cast instance);
 	}
 }

--- a/src/swf/runtime/MovieClip.hx
+++ b/src/swf/runtime/MovieClip.hx
@@ -218,7 +218,20 @@ class MovieClipTimeline extends Timeline
 		}
 
 		#if !flash
+		setChildField(displayObject);
+		#end
+	}
+
+	@:noCompletion private inline function setChildField(displayObject:DisplayObject)
+	{
+		#if (openfl_dynamic && haxe_ver < "4.0.0")
 		Reflect.setField(movieClip, displayObject.name, displayObject);
+		#else
+		// Check that the type allows this field
+		if (Type.getInstanceFields(Type.getClass(movieClip)).indexOf(displayObject.name) != -1)
+		{
+			Reflect.setField(movieClip, displayObject.name, displayObject);
+		}
 		#end
 	}
 

--- a/src/swf/runtime/MovieClip.hx
+++ b/src/swf/runtime/MovieClip.hx
@@ -22,6 +22,10 @@ class MovieClip extends #if flash openfl.display.MovieClip.MovieClip2 #else open
 	{
 		super();
 		attachTimeline(new MovieClipTimeline(data));
+		
+		#if !flash
+		__enterFrame(0);
+		#end
 	}
 }
 


### PR DESCRIPTION
I tried out [openfl-player](https://github.com/openfl/openfl-player) and found some issues with runtime Swf parsing and swflite. these were the changes needed to get the project working.

I couldn't get any swfs to render on html5, except with swflite. the only swf that worked on html5 with swflite was badgerbadger, and my own custom swf. @barisyild mentioned they couldn't get as2 swfs to work with swflite. Any leads on why html5 doesn't work without swflite would be greatly appreciated.

I'm not sure this is the best way to handle, things. Specifically [MovieClip.setChildField](https://github.com/openfl/swf/pull/15/files#diff-332b1c2b9ac3102bb0875f91eeaf425e5535f75e9c00904fd175a8796925dbd5R229) and [SpriteSymbol.__setConstructor](https://github.com/openfl/swf/pull/15/files#diff-601a421406cc2d6f64f4ede01bd65452b39ed9a62bcdf83dbfea01c61502f7a5R51). The use of `__constructor` here seems odd and dangerous, to begin with. why not just call `__constructor` on the created movieclip in `__createObject`?