### PR TITLE
Fix for: 'WARNING: Could not find required font "X", it has not been embedded'

### DIFF
--- a/src/swf/exporters/animate/AnimateDynamicTextSymbol.hx
+++ b/src/swf/exporters/animate/AnimateDynamicTextSymbol.hx
@@ -120,10 +120,11 @@ class AnimateDynamicTextSymbol extends AnimateSymbol
 		if (!found)
 		{
 			var alpha = ~/[^a-zA-Z]+/g;
+			var spaces = ~/\s/g;
 
 			for (font in Font.enumerateFonts())
 			{
-				if (alpha.replace(font.fontName, "").substr(0, fontName.length) == fontName)
+				if (alpha.replace(font.fontName, "").substr(0, fontName.length) == spaces.replace(fontName, ""))
 				{
 					format.font = font.fontName;
 					found = true;

--- a/src/swf/exporters/swflite/DynamicTextSymbol.hx
+++ b/src/swf/exporters/swflite/DynamicTextSymbol.hx
@@ -120,10 +120,11 @@ class DynamicTextSymbol extends SWFSymbol
 		if (!found)
 		{
 			var alpha = ~/[^a-zA-Z]+/g;
+			var spaces = ~/\s/g;
 
 			for (font in Font.enumerateFonts())
 			{
-				if (alpha.replace(font.fontName, "").substr(0, fontName.length) == fontName)
+				if (alpha.replace(font.fontName, "").substr(0, fontName.length) == spaces.replace(fontName, ""))
 				{
 					format.font = font.fontName;
 					found = true;


### PR DESCRIPTION
Sometimes an embedded font can't be found because there's a mismatch between OpenFL's registered font names and the 'real' font name.

For example the font 'Arbuckle Remix NF' gets registered as 'ArbuckleRemixNF' and fails this check:
[if (alpha.replace(font.fontName, "").substr(0, fontName.length) == fontName)](https://github.com/openfl/swf/blob/16d1c9c368b9a288c56ee6e5882bfc96c8e73db7/src/swf/exporters/animate/AnimateDynamicTextSymbol.hx#L126)
because 'ArbuckleRemixNF' is not 'Arbuckle Remix NF'.

This pull request takes care of this.