### PR TITLE
unload memory leak fix

### DIFF
--- a/src/swf/exporters/animate/AnimateLibrary.hx
+++ b/src/swf/exporters/animate/AnimateLibrary.hx
@@ -73,6 +73,7 @@ import openfl.filters.GlowFilter;
 		super();
 
 		this.id = id;
+		this.uuid = uuid;
 
 		instanceID = uuid != null ? uuid : id;
 


### PR DESCRIPTION
This commit fixes a memory leak in the unload function.

https://github.com/barisyild/swf/blob/944c50f29d89f8c7bc6614ed2aaf9a95ce17a0d8/src/swf/exporters/animate/AnimateLibrary.hx#L449