### PR TITLE
Add support to ActionScript 2 and ExportAssets on SWF to AnimateLibraryExporter

### DIFF
--- a/src/swf/exporters/AnimateLibraryExporter.hx
+++ b/src/swf/exporters/AnimateLibraryExporter.hx
@@ -1,5 +1,6 @@
 package swf.exporters;
 
+import swf.tags.TagFileAttributes;
 import format.png.Data;
 import format.png.Writer as PNGWriter;
 import swf.data.consts.BitmapFormat;
@@ -28,6 +29,7 @@ import swf.tags.TagDefineSprite;
 import swf.tags.TagDefineText;
 import swf.tags.TagPlaceObject;
 import swf.tags.TagSymbolClass;
+import swf.tags.TagExportAssets;
 import swf.timeline.Frame;
 import swf.utils.SymbolUtils;
 import swf.SWFRoot;
@@ -70,6 +72,7 @@ class AnimateLibraryExporter
 	private var symbols:Array<SWFSymbol>;
 	private var symbolsByTagID:Map<Int, SWFSymbol>;
 	private var targetPath:String;
+	private var isActionScript3:Bool = true;
 
 	public function new(swfData:SWFRoot, targetPath:String)
 	{
@@ -88,6 +91,18 @@ class AnimateLibraryExporter
 					symbols.push(symbol);
 					symbolsByTagID.set(symbol.tagId, symbol);
 				}
+			}
+			if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagExportAssets))
+			{
+				for (symbol in cast(tag, TagExportAssets).symbols)
+				{
+					symbols.push(symbol);
+					symbolsByTagID.set(symbol.tagId, symbol);
+				}
+			}
+			if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagFileAttributes))
+			{
+				isActionScript3 = cast(tag, TagFileAttributes).actionscript3;
 			}
 		}
 
@@ -809,7 +824,7 @@ class AnimateLibraryExporter
 		var found = false;
 
 		var swfSymbol = symbolsByTagID.get(symbol.id);
-		if (swfSymbol != null)
+		if (swfSymbol != null && isActionScript3)
 		{
 			var scripts = FrameScriptParser.convertToJS(swfData, swfSymbol.name);
 			if (scripts != null)
@@ -1318,7 +1333,7 @@ class AnimateLibraryExporter
 		if (data2 != null && symbol.name != null)
 		{
 			data2.className = symbol.name;
-			data2.baseClassName = FrameScriptParser.getBaseClassName(swfData, symbol.name);
+			data2.baseClassName = isActionScript3 ? FrameScriptParser.getBaseClassName(swfData, symbol.name) : "flash.display.MovieClip";
 		}
 	}
 


### PR DESCRIPTION
Allows `swf process` to work with AS2 SWF (and theoretically AS3 swf who use ExportAssets too)