### PR TITLE
Fix exporters for assets without ABC or SymbolClass tags

### DIFF
--- a/src/swf/SWFRoot.hx
+++ b/src/swf/SWFRoot.hx
@@ -12,6 +12,7 @@ import swf.events.SWFProgressEvent;
 import openfl.utils.ByteArray;
 import openfl.utils.CompressionAlgorithm;
 import openfl.errors.Error;
+import swf.tags.TagExportAssets;
 import swf.tags.TagSymbolClass;
 
 class SWFRoot extends SWFTimelineContainer
@@ -58,6 +59,13 @@ class SWFRoot extends SWFTimelineContainer
 			if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagSymbolClass))
 			{
 				for (symbol in cast(tag, TagSymbolClass).symbols)
+				{
+					symbols.set(symbol.name, symbol.tagId);
+				}
+			}
+			else if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagExportAssets))
+			{
+				for (symbol in cast(tag, TagExportAssets).symbols)
 				{
 					symbols.set(symbol.name, symbol.tagId);
 				}

--- a/src/swf/exporters/AnimateLibraryExporter.hx
+++ b/src/swf/exporters/AnimateLibraryExporter.hx
@@ -26,6 +26,7 @@ import swf.tags.TagDefineShape;
 import swf.tags.TagDefineSound;
 import swf.tags.TagDefineSprite;
 import swf.tags.TagDefineText;
+import swf.tags.TagExportAssets;
 import swf.tags.TagPlaceObject;
 import swf.tags.TagSymbolClass;
 import swf.timeline.Frame;
@@ -84,6 +85,14 @@ class AnimateLibraryExporter
 			if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagSymbolClass))
 			{
 				for (symbol in cast(tag, TagSymbolClass).symbols)
+				{
+					symbols.push(symbol);
+					symbolsByTagID.set(symbol.tagId, symbol);
+				}
+			}
+			else if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagExportAssets))
+			{
+				for (symbol in cast(tag, TagExportAssets).symbols)
 				{
 					symbols.push(symbol);
 					symbolsByTagID.set(symbol.tagId, symbol);

--- a/src/swf/exporters/AnimateLibraryExporter.hx
+++ b/src/swf/exporters/AnimateLibraryExporter.hx
@@ -179,6 +179,7 @@ class AnimateLibraryExporter
 		var outputFile = File.write(targetPath, true);
 		var writer = new ZipWriter(outputFile);
 		writer.write(outputList);
+		outputFile.close();
 	}
 
 	private function addButton(tag:IDefinitionTag):Dynamic

--- a/src/swf/exporters/FrameScriptParser.hx
+++ b/src/swf/exporters/FrameScriptParser.hx
@@ -13,6 +13,11 @@ class FrameScriptParser
 
 	public static function getBaseClassName(swfData:SWFRoot, className:String):String
 	{
+		if (swfData == null || swfData.abcData == null)
+		{
+			return null;
+		}
+
 		var classData = swfData.abcData.findClassByName(className);
 		if (classData != null && classData.superclass != null)
 		{
@@ -36,6 +41,11 @@ class FrameScriptParser
 
 	public static function convertToJS(swfData:SWFRoot, className:String):Array<String>
 	{
+		if (swfData == null || swfData.abcData == null)
+		{
+			return null;
+		}
+
 		indentationLevel = 0;
 		var cls = swfData.abcData.findClassByName(className);
 		var scripts = null;
@@ -824,7 +834,7 @@ class AVM2
 
 	public static function findClassByName(abcData:ABCData, s:String):ClassDef
 	{
-		if (s == null) return null;
+		if (abcData == null || s == null) return null;
 
 		var x = s.lastIndexOf(".");
 		var pkgName = "";
@@ -858,6 +868,11 @@ class AVM2
 
 	public static function classHasField(abcData:ABCData, cls:ClassDef, name:String):Bool
 	{
+		if (abcData == null || cls == null || name == null)
+		{
+			return false;
+		}
+
 		var classHasField = false;
 
 		for (field in cls.fields)

--- a/src/swf/exporters/SWFLiteExporter.hx
+++ b/src/swf/exporters/SWFLiteExporter.hx
@@ -45,6 +45,7 @@ import swf.tags.TagDefineScalingGrid;
 import swf.tags.TagDefineShape;
 import swf.tags.TagDefineSprite;
 import swf.tags.TagDefineText;
+import swf.tags.TagExportAssets;
 import swf.tags.TagPlaceObject;
 import swf.tags.TagSymbolClass;
 import swf.SWFRoot;
@@ -97,6 +98,14 @@ class SWFLiteExporter
 			if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagSymbolClass))
 			{
 				for (symbol in cast(tag, TagSymbolClass).symbols)
+				{
+					processSymbol(symbol);
+					symbolsByTagID.set(symbol.tagId, symbol);
+				}
+			}
+			else if (#if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (tag, TagExportAssets))
+			{
+				for (symbol in cast(tag, TagExportAssets).symbols)
 				{
 					processSymbol(symbol);
 					symbolsByTagID.set(symbol.tagId, symbol);


### PR DESCRIPTION
## Summary

This fixes SWF exporter/runtime issues for assets that do not include ABC data or SymbolClass tags.

It also includes a small EOF-related fix in `AnimateLibraryExporter` that was encountered while handling these assets.

## Changes

- avoid EOF failure in `AnimateLibraryExporter`
- handle assets that do not provide ABC data
- handle assets that do not provide SymbolClass tags
- make related exporter/runtime paths more defensive