### PR TITLE
Cache timeline instance fields by class name

### DIFF
--- a/src/swf/exporters/animate/AnimateTimeline.hx
+++ b/src/swf/exporters/animate/AnimateTimeline.hx
@@ -34,6 +34,8 @@ import hscript.Parser;
 @:access(openfl.geom.ColorTransform)
 class AnimateTimeline extends Timeline
 {
+	@:noCompletion private static var __instanceFieldsCacheByClassName:Map<String, Array<String>> = new Map();
+
 	#if 0
 	// Suppress checkstyle warning
 	private static var __unusedImport:Array<Class<Dynamic>> = [
@@ -420,7 +422,7 @@ class AnimateTimeline extends Timeline
 		}
 
 		#if !openfljs
-		__instanceFields = Type.getInstanceFields(Type.getClass(__sprite));
+		__instanceFields = __getCachedInstanceFields(__sprite);
 		#end
 
 		enterFrame(1);
@@ -496,7 +498,7 @@ class AnimateTimeline extends Timeline
 
 			displayObject.filters = filters;
 		}
-		else
+		else if (reset && displayObject.filters != null)
 		{
 			displayObject.filters = null;
 		}
@@ -545,6 +547,30 @@ class AnimateTimeline extends Timeline
 				}
 			}
 		}
+	}
+
+	@:noCompletion private static function __getCachedInstanceFields(displayObject:DisplayObject):Array<String>
+	{
+		var clazz = Type.getClass(displayObject);
+		if (clazz == null)
+		{
+			return [];
+		}
+
+		var className = Type.getClassName(clazz);
+		if (className == null)
+		{
+			return Type.getInstanceFields(clazz);
+		}
+
+		var cached = __instanceFieldsCacheByClassName.get(className);
+		if (cached == null)
+		{
+			cached = Type.getInstanceFields(clazz);
+			__instanceFieldsCacheByClassName.set(className, cached);
+		}
+
+		return cached;
 	}
 
 	#if hscript

--- a/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
+++ b/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
@@ -39,6 +39,8 @@ import hscript.Parser;
 @:access(openfl.geom.ColorTransform)
 class SymbolTimeline extends Timeline
 {
+	@:noCompletion private static var __instanceFieldsCacheByClassName:Map<String, Array<String>> = new Map();
+
 	#if openfljs
 	@:noCompletion private static var __useParentFPS:Bool;
 	#else
@@ -256,7 +258,7 @@ class SymbolTimeline extends Timeline
 		}
 
 		#if !openfljs
-		__instanceFields = Type.getInstanceFields(Type.getClass(movieClip));
+		__instanceFields = __getCachedInstanceFields(movieClip);
 		#end
 
 		enterFrame(1);
@@ -468,7 +470,7 @@ class SymbolTimeline extends Timeline
 
 			displayObject.filters = filters;
 		}
-		else
+		else if (reset && displayObject.filters != null)
 		{
 			displayObject.filters = null;
 		}
@@ -510,6 +512,30 @@ class SymbolTimeline extends Timeline
 				}
 			}
 		}
+	}
+
+	@:noCompletion private static function __getCachedInstanceFields(displayObject:DisplayObject):Array<String>
+	{
+		var clazz = Type.getClass(displayObject);
+		if (clazz == null)
+		{
+			return [];
+		}
+
+		var className = Type.getClassName(clazz);
+		if (className == null)
+		{
+			return Type.getInstanceFields(clazz);
+		}
+
+		var cached = __instanceFieldsCacheByClassName.get(className);
+		if (cached == null)
+		{
+			cached = Type.getInstanceFields(clazz);
+			__instanceFieldsCacheByClassName.set(className, cached);
+		}
+
+		return cached;
 	}
 }
 


### PR DESCRIPTION
## Summary

This caches `Type.getInstanceFields()` results per class name in timeline code.

## Motivation

Timeline attachment/update can hit the same reflection path many times when many symbols of the same class are instantiated.

## Changes

- cache instance field lists by class name in `AnimateTimeline`
- cache instance field lists by class name in `SymbolTimeline`

## Impact

This reduces repeated reflection work and should lower CPU and GC pressure in symbol-heavy scenes.