### PR TITLE
Preserve timeline-created instances from removed-child cleanup

### DIFF
--- a/src/swf/exporters/animate/AnimateTimeline.hx
+++ b/src/swf/exporters/animate/AnimateTimeline.hx
@@ -398,6 +398,7 @@ class AnimateTimeline extends Timeline
 
 								// if (__sprite.stage != null) displayObject.dispatchEvent(new Event(Event.ADDED_TO_STAGE, false, false));
 								#end
+								displayObject.__removedChildCleanupDelay = Math.POSITIVE_INFINITY;
 
 								instance = new FrameSymbolInstance(frame, frameObject.id, frameObject.symbol, frameObject.depth, displayObject,
 									frameObject.clipDepth);

--- a/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
+++ b/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
@@ -234,6 +234,7 @@ class SymbolTimeline extends Timeline
 								// displayObject.stage = __movieClip.stage;
 
 								// if (__movieClip.stage != null) displayObject.dispatchEvent(new Event(Event.ADDED_TO_STAGE, false, false));
+								displayObject.__removedChildCleanupDelay = Math.POSITIVE_INFINITY;
 
 								instance = new FrameSymbolInstance(frame, frameObject.id, frameObject.symbol, frameObject.depth, displayObject,
 									frameObject.clipDepth);


### PR DESCRIPTION
## Summary

This sets `__removedChildCleanupDelay = Math.POSITIVE_INFINITY` on display objects created by the Animate and SWFLite timelines.

These timeline instances are intended to be reused after being removed from the display list. With the default OpenFL behavior, removed-child cleanup may run immediately and dispose internal cached state before the instance is reused.

## Dependency

This PR depends on the companion OpenFL PR that adds delayed removed-child cleanup support: [openfl/openfl#2850](https://github.com/openfl/openfl/pull/2850).

## Why this change is needed

The end-user symptom is not perfectly reproducible on every machine because it depends on OS/runtime/native memory behavior.

That said, the underlying issue is deterministic:

- timeline-created display objects are reused
- OpenFL schedules removed-child cleanup immediately by default
- reusable timeline instances should not be cleaned up between removals and reinsertions

This patch aligns the cleanup behavior with the actual lifecycle of those instances.

## Observed effects

On the most affected systems, native memory could previously start near its normal baseline and then climb to several gigabytes within roughly ten minutes. After this change, it stays close to the initial baseline over the same period, or only increases slightly and an order of magnitude more slowly.

I also observed cases where memory was already relatively stable, but the initial/native memory footprint was still reduced after this change. For example, on a native Linux build of the same project, RAM usage dropped from about 790 MB to about 670 MB while remaining very stable.

Other testers also reported lower initial memory usage on Windows, even on machines where the original issue was less severe.

## Suggested validation

If you want to verify the effect on your side, I think the most representative test would be a medium/large project that uses many SWF files and already consumes a noticeable amount of RAM. A very small sample may not show a meaningful difference.