### PR TITLE
Fix Animate generated class inclusion and duplicate runtime resolution

### DIFF
--- a/scripts/Tools.hx
+++ b/scripts/Tools.hx
@@ -55,6 +55,67 @@ class Tools
 	private static var targetDirectory:String;
 	private static var targetFlags:Map<String, String>;
 
+	private static function readGeneratedClassesFile(path:String):Array<String>
+	{
+		if (path == null || !FileSystem.exists(path))
+		{
+			return null;
+		}
+
+		var generatedClasses = [];
+		for (line in File.getContent(path).split("\n"))
+		{
+			var className = StringTools.trim(line);
+			if (className != "" && !StringTools.startsWith(className, "#"))
+			{
+				generatedClasses.push(className);
+			}
+		}
+
+		return generatedClasses;
+	}
+
+	private static function writeGeneratedClassesCache(path:String, generatedClasses:Array<String>):Void
+	{
+		if (path == null)
+		{
+			return;
+		}
+
+		File.saveContent(path, generatedClasses.join("\n"));
+	}
+
+	private static function deleteGeneratedClassFiles(targetPath:String, classNames:Array<String>):Void
+	{
+		if (targetPath == null || classNames == null)
+		{
+			return;
+		}
+
+		for (className in classNames)
+		{
+			if (className == null || className == "")
+			{
+				continue;
+			}
+
+			var classPath = Path.combine(targetPath, className.split(".").join("/") + ".hx");
+
+			if (FileSystem.exists(classPath))
+			{
+				FileSystem.deleteFile(classPath);
+			}
+		}
+	}
+
+	private static function pushUniqueHaxeflag(output:HXProject, value:String):Void
+	{
+		if (value != null && output.haxeflags.indexOf(value) == -1)
+		{
+			output.haxeflags.push(value);
+		}
+	}
+
 	#if neko
 	public static function __init__()
 	{
@@ -996,7 +1057,7 @@ class Tools
 
 					for (className in generatedClasses)
 					{
-						output.haxeflags.push(className);
+						pushUniqueHaxeflag(output, className);
 					}
 				}
 
@@ -1018,11 +1079,14 @@ class Tools
 				var cacheAvailable = false;
 				var cacheDirectory = null;
 				var cacheFile = null;
+				var generatedClassesFile = null;
+				var cachedGeneratedClasses:Array<String> = null;
 
 				if (targetDirectory != null)
 				{
 					cacheDirectory = targetDirectory + "/obj/libraries";
 					cacheFile = cacheDirectory + "/" + library.name + ".zip";
+					generatedClassesFile = cacheDirectory + "/" + library.name + ".classes.txt";
 
 					if (FileSystem.exists(cacheFile))
 					{
@@ -1033,6 +1097,16 @@ class Tools
 						if (sourceDate.getTime() < cacheDate.getTime() && toolDate.getTime() < cacheDate.getTime())
 						{
 							cacheAvailable = true;
+						}
+					}
+
+					if (cacheAvailable && library.generate != false)
+					{
+						cachedGeneratedClasses = readGeneratedClassesFile(generatedClassesFile);
+
+						if (cachedGeneratedClasses == null)
+						{
+							cacheAvailable = false;
 						}
 					}
 
@@ -1056,6 +1130,7 @@ class Tools
 						if (library.generate != false)
 						{
 							var targetPath:String;
+							var previousGeneratedClasses = readGeneratedClassesFile(generatedClassesFile);
 
 							if (project.target == IOS)
 							{
@@ -1067,26 +1142,42 @@ class Tools
 							}
 
 							var generatedClasses = exporter.generateClasses(targetPath, output.assets, library.prefix);
+							var generatedLookup = new Map<String, Bool>();
 
-							// for (className in generatedClasses)
-							// {
-							// 	output.haxeflags.push(className);
-							// }
+							for (className in generatedClasses)
+							{
+								generatedLookup.set(className, true);
+							}
 
-							// if (cacheDirectory != null)
-							// {
-							// 	File.saveContent(cacheDirectory + "/classNames.txt", generatedClasses.join("\n"));
-							// }
+							if (previousGeneratedClasses != null)
+							{
+								var removedGeneratedClasses = [];
+
+								for (className in previousGeneratedClasses)
+								{
+									if (!generatedLookup.exists(className))
+									{
+										removedGeneratedClasses.push(className);
+									}
+								}
+
+								deleteGeneratedClassFiles(targetPath, removedGeneratedClasses);
+							}
+
+								for (className in generatedClasses)
+								{
+									pushUniqueHaxeflag(output, className);
+								}
+
+							writeGeneratedClassesCache(generatedClassesFile, generatedClasses);
 						}
 					}
-					else
+					else if (library.generate != false && cachedGeneratedClasses != null)
 					{
-						// var generatedClasses = File.getContent(cacheDirectory + "/classNames.txt").split("\n");
-
-						// for (className in generatedClasses)
-						// {
-						// 	output.haxeflags.push(className);
-						// }
+						for (className in cachedGeneratedClasses)
+						{
+							pushUniqueHaxeflag(output, className);
+						}
 					}
 
 					var asset = new Asset(cacheFile, "lib/" + library.name + ".zip", AssetType.BUNDLE);

--- a/src/swf/exporters/animate/AnimateBitmapSymbol.hx
+++ b/src/swf/exporters/animate/AnimateBitmapSymbol.hx
@@ -1,5 +1,6 @@
 package swf.exporters.animate;
 
+import swf.utils.SymbolUtils;
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
 import openfl.display.PixelSnapping;
@@ -14,6 +15,9 @@ class AnimateBitmapSymbol extends AnimateSymbol
 	public var path:String;
 	public var smooth:Null<Bool>;
 
+	private var resolvedSymbolType:Class<Dynamic>;
+	private var resolvedSymbolTypeReady = false;
+
 	public function new()
 	{
 		super();
@@ -22,9 +26,53 @@ class AnimateBitmapSymbol extends AnimateSymbol
 	private override function __createObject(library:AnimateLibrary):Bitmap
 	{
 		#if lime
-		return new Bitmap(BitmapData.fromImage(library.getImage(path)), PixelSnapping.AUTO, smooth != false);
+		return new Bitmap(__createBitmapData(library), PixelSnapping.AUTO, smooth != false);
 		#else
 		return null;
 		#end
+	}
+
+	private function __createBitmapData(library:AnimateLibrary):BitmapData
+	{
+		var symbolType = __resolveSymbolType();
+
+		if (symbolType != null)
+		{
+			AnimateGeneratedTypeContext.setBitmap(library, this);
+
+			try
+			{
+				var bitmapData:BitmapData = cast Type.createInstance(symbolType, []);
+				AnimateGeneratedTypeContext.clearBitmapIfMatches(library, this);
+				if (bitmapData != null)
+				{
+					return bitmapData;
+				}
+			}
+			catch (e:Dynamic)
+			{
+				AnimateGeneratedTypeContext.clearBitmap();
+				throw e;
+			}
+		}
+
+		return BitmapData.fromImage(library.getImage(path));
+	}
+
+	private function __resolveSymbolType():Class<Dynamic>
+	{
+		if (className == null)
+		{
+			return null;
+		}
+
+		if (resolvedSymbolTypeReady)
+		{
+			return resolvedSymbolType;
+		}
+
+		resolvedSymbolType = Type.resolveClass(SymbolUtils.formatClassName(className));
+		resolvedSymbolTypeReady = true;
+		return resolvedSymbolType;
 	}
 }

--- a/src/swf/exporters/animate/AnimateButtonSymbol.hx
+++ b/src/swf/exporters/animate/AnimateButtonSymbol.hx
@@ -65,11 +65,18 @@ class AnimateButtonSymbol extends AnimateSymbol
 
 			if (symbolType != null)
 			{
-				simpleButton = Type.createInstance(symbolType, []);
-			}
-			else
-			{
-				// Log.warn ("Could not resolve class \"" + symbol.className + "\"");
+				AnimateGeneratedTypeContext.setButton(library, this);
+
+				try
+				{
+					simpleButton = Type.createInstance(symbolType, []);
+					AnimateGeneratedTypeContext.clearButtonIfMatches(library, this);
+				}
+				catch (e:Dynamic)
+				{
+					AnimateGeneratedTypeContext.clearButton();
+					throw e;
+				}
 			}
 		}
 

--- a/src/swf/exporters/animate/AnimateGeneratedTypeContext.hx
+++ b/src/swf/exporters/animate/AnimateGeneratedTypeContext.hx
@@ -1,0 +1,137 @@
+package swf.exporters.animate;
+
+class AnimateGeneratedTypeContext
+{
+	public static var currentBitmapLibrary(default, null):AnimateLibrary;
+	public static var currentBitmapSymbol(default, null):AnimateBitmapSymbol;
+	public static var currentButtonLibrary(default, null):AnimateLibrary;
+	public static var currentButtonSymbol(default, null):AnimateButtonSymbol;
+	public static var currentLibrary(default, null):AnimateLibrary;
+	public static var currentSpriteSymbol(default, null):AnimateSpriteSymbol;
+
+	public static function setBitmap(library:AnimateLibrary, symbol:AnimateBitmapSymbol):Void
+	{
+		currentBitmapLibrary = library;
+		currentBitmapSymbol = symbol;
+	}
+
+	public static function clearBitmap():Void
+	{
+		currentBitmapLibrary = null;
+		currentBitmapSymbol = null;
+	}
+
+	public static function clearBitmapIfMatches(library:AnimateLibrary, symbol:AnimateBitmapSymbol):Void
+	{
+		if (currentBitmapLibrary == library && currentBitmapSymbol == symbol)
+		{
+			clearBitmap();
+		}
+	}
+
+	public static function consumeBitmap():AnimateGeneratedBitmapContext
+	{
+		if (currentBitmapLibrary == null || currentBitmapSymbol == null)
+		{
+			return null;
+		}
+
+		var context:AnimateGeneratedBitmapContext = {
+			library: currentBitmapLibrary,
+			symbol: currentBitmapSymbol
+		};
+
+		clearBitmap();
+		return context;
+	}
+
+	public static function setButton(library:AnimateLibrary, symbol:AnimateButtonSymbol):Void
+	{
+		currentButtonLibrary = library;
+		currentButtonSymbol = symbol;
+	}
+
+	public static function clearButton():Void
+	{
+		currentButtonLibrary = null;
+		currentButtonSymbol = null;
+	}
+
+	public static function clearButtonIfMatches(library:AnimateLibrary, symbol:AnimateButtonSymbol):Void
+	{
+		if (currentButtonLibrary == library && currentButtonSymbol == symbol)
+		{
+			clearButton();
+		}
+	}
+
+	public static function consumeButton():AnimateGeneratedButtonContext
+	{
+		if (currentButtonLibrary == null || currentButtonSymbol == null)
+		{
+			return null;
+		}
+
+		var context:AnimateGeneratedButtonContext = {
+			library: currentButtonLibrary,
+			symbol: currentButtonSymbol
+		};
+
+		clearButton();
+		return context;
+	}
+
+	public static function setSprite(library:AnimateLibrary, symbol:AnimateSpriteSymbol):Void
+	{
+		currentLibrary = library;
+		currentSpriteSymbol = symbol;
+	}
+
+	public static function clearSprite():Void
+	{
+		currentLibrary = null;
+		currentSpriteSymbol = null;
+	}
+
+	public static function clearSpriteIfMatches(library:AnimateLibrary, symbol:AnimateSpriteSymbol):Void
+	{
+		if (currentLibrary == library && currentSpriteSymbol == symbol)
+		{
+			clearSprite();
+		}
+	}
+
+	public static function consumeSprite():AnimateGeneratedSpriteContext
+	{
+		if (currentLibrary == null || currentSpriteSymbol == null)
+		{
+			return null;
+		}
+
+		var context:AnimateGeneratedSpriteContext = {
+			library: currentLibrary,
+			symbol: currentSpriteSymbol
+		};
+
+		clearSprite();
+		return context;
+	}
+}
+
+typedef AnimateGeneratedBitmapContext =
+{
+	var library:AnimateLibrary;
+	var symbol:AnimateBitmapSymbol;
+}
+
+typedef AnimateGeneratedButtonContext =
+{
+	var library:AnimateLibrary;
+	var symbol:AnimateButtonSymbol;
+}
+
+typedef AnimateGeneratedSpriteContext =
+{
+	var library:AnimateLibrary;
+	var symbol:AnimateSpriteSymbol;
+}

--- a/src/swf/exporters/animate/AnimateSpriteSymbol.hx
+++ b/src/swf/exporters/animate/AnimateSpriteSymbol.hx
@@ -90,7 +90,18 @@ class AnimateSpriteSymbol extends AnimateSymbol
 
 		if (symbolType != null)
 		{
-			sprite = Type.createInstance(symbolType, []);
+			AnimateGeneratedTypeContext.setSprite(library, this);
+
+			try
+			{
+				sprite = Type.createInstance(symbolType, []);
+				AnimateGeneratedTypeContext.clearSpriteIfMatches(library, this);
+			}
+			catch (e:Dynamic)
+			{
+				AnimateGeneratedTypeContext.clearSprite();
+				throw e;
+			}
 		}
 		else
 		{

--- a/templates/animate/BitmapData.mtt
+++ b/templates/animate/BitmapData.mtt
@@ -8,8 +8,9 @@ class ::CLASS_NAME:: extends openfl.display.BitmapData
 	{
 		super(0, 0, true, 0);
 
-		var library = swf.exporters.animate.AnimateLibrary.get("::UUID::");
-		var symbol:swf.exporters.animate.AnimateBitmapSymbol = cast library.symbols.get(::SYMBOL_ID::);
+		var context = swf.exporters.animate.AnimateGeneratedTypeContext.consumeBitmap();
+		var library = context != null ? context.library : swf.exporters.animate.AnimateLibrary.get("::UUID::");
+		var symbol:swf.exporters.animate.AnimateBitmapSymbol = context != null ? context.symbol : cast library.symbols.get(::SYMBOL_ID::);
 		var image = library.getImage(symbol.path);
 		__fromImage(image);
 	}

--- a/templates/animate/MovieClip.mtt
+++ b/templates/animate/MovieClip.mtt
@@ -9,9 +9,17 @@ class ::CLASS_NAME:: extends ::if BASE_CLASS_NAME::::BASE_CLASS_NAME::::else::#i
 
 	public function new()
 	{
-		var library = swf.exporters.animate.AnimateLibrary.get("::UUID::");
-		var symbol = library.symbols.get(::SYMBOL_ID::);
-		symbol.__init(library);
+		var context = swf.exporters.animate.AnimateGeneratedTypeContext.consumeSprite();
+		if (context != null)
+		{
+			context.symbol.__init(context.library);
+		}
+		else
+		{
+			var library = swf.exporters.animate.AnimateLibrary.get("::UUID::");
+			var symbol = library.symbols.get(::SYMBOL_ID::);
+			symbol.__init(library);
+		}
 
 		super();
 	}

--- a/templates/animate/SimpleButton.mtt
+++ b/templates/animate/SimpleButton.mtt
@@ -6,9 +6,17 @@ class ::CLASS_NAME:: extends ::if BASE_CLASS_NAME::::BASE_CLASS_NAME::::else::#i
 {
 	public function new()
 	{
-		var library = swf.exporters.animate.AnimateLibrary.get("::UUID::");
-		var symbol = library.symbols.get(::SYMBOL_ID::);
-		symbol.__init(library);
+		var context = swf.exporters.animate.AnimateGeneratedTypeContext.consumeButton();
+		if (context != null)
+		{
+			context.symbol.__init(context.library);
+		}
+		else
+		{
+			var library = swf.exporters.animate.AnimateLibrary.get("::UUID::");
+			var symbol = library.symbols.get(::SYMBOL_ID::);
+			symbol.__init(library);
+		}
 
 		super();
 	}


### PR DESCRIPTION
## Summary

This PR fixes two separate Animate-related issues.

1. Generated Animate linkage classes were not being reliably included in the Haxe build when `generate="true"` was enabled on libraries. In practice, this meant some symbols that should have been instantiated as their exported class fell back to generic `MovieClip` instances on C++/OpenFL. For the game case that motivated this work, nested collision symbols such as `NavCollisionRectangle` then became impossible to identify and remove by class name, which caused the visible red collision overlays. The first part of this PR fixes the tooling side so that `generate="true"` works correctly for the selected libraries.

2. Once generated classes are enabled across multiple libraries, duplicate exported class names can resolve to the wrong library at runtime. Generated classes were effectively tied to a specific `UUID + symbolID`, so another library exporting the same class name could instantiate the wrong symbol. The second part of this PR fixes that runtime resolution so generated classes are bound to the library that is actually instantiating them.

## Changes

- fix the Animate tooling path in `Tools.hx` so generated classes are actually added to the Haxe build and restored from cache correctly
- make Animate generated `MovieClip` classes resolve against the runtime library being instantiated, instead of a fixed library/symbol pair
- apply the same runtime-resolution strategy to generated `SimpleButton` classes
- keep `BitmapData` aligned with the same strategy for consistency/future-proofing

## Repro
[SWFAnimateCollisionRepro.zip](https://github.com/user-attachments/files/26423718/SWFAnimateCollisionRepro.zip)

A minimal repro project is included to demonstrate:

- the original visible collision-overlay issue when generation is disabled
- wrong duplicate-linkage resolution for shared `MovieClip` and `SimpleButton` exports when the runtime-library fix is removed
- a separate unresolved issue where enabling generation on certain UI assets can emit classes extending `fl.controls.ScrollBar`, which does not exist on Haxe/OpenFL. This PR does not fix that issue, it is included only to document it in case someone wants to investigate it separately.

## Note

This PR depends on https://github.com/openfl/swf/pull/40.