### PR TITLE
Hide clipping characters without active mask targets

### DIFF
--- a/src/swf/exporters/animate/AnimateTimeline.hx
+++ b/src/swf/exporters/animate/AnimateTimeline.hx
@@ -243,6 +243,7 @@ class AnimateTimeline extends Timeline
 					}
 
 					child = targetChild;
+
 					maskApplied = false;
 
 					for (mask in currentMasks)
@@ -263,6 +264,11 @@ class AnimateTimeline extends Timeline
 					{
 						child.mask = null;
 					}
+				}
+
+				for (mask in currentMasks)
+				{
+					__markTimelineMask(mask.displayObject);
 				}
 
 				// TODO: How to tell if shapes are for a scale9Grid clip?
@@ -444,6 +450,16 @@ class AnimateTimeline extends Timeline
 	@:noCompletion private function __sortDepths(a:FrameSymbolInstance, b:FrameSymbolInstance):Int
 	{
 		return a.depth - b.depth;
+	}
+
+	@:noCompletion private inline function __markTimelineMask(displayObject:DisplayObject):Void
+	{
+		// SWF clipDepth>0 placements are masks even before a child exists in their depth range.
+		if (!displayObject.__isMask)
+		{
+			displayObject.__isMask = true;
+			displayObject.__setRenderDirty();
+		}
 	}
 
 	@:noCompletion private function __updateDisplayObject(displayObject:DisplayObject, frameObject:AnimateFrameObject, reset:Bool = false):Void

--- a/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
+++ b/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
@@ -376,6 +376,11 @@ class SymbolTimeline extends Timeline
 				}
 			}
 
+			for (mask in currentMasks)
+			{
+				__markTimelineMask(mask.displayObject);
+			}
+
 			var child:DisplayObject;
 			var i = currentInstances.length;
 			var length = __movieClip.numChildren;
@@ -417,6 +422,16 @@ class SymbolTimeline extends Timeline
 	@:noCompletion private function __sortDepths(a:FrameSymbolInstance, b:FrameSymbolInstance):Int
 	{
 		return a.depth - b.depth;
+	}
+
+	@:noCompletion private inline function __markTimelineMask(displayObject:DisplayObject):Void
+	{
+		// SWF clipDepth>0 placements are masks even before a child exists in their depth range.
+		if (!displayObject.__isMask)
+		{
+			displayObject.__isMask = true;
+			displayObject.__setRenderDirty();
+		}
 	}
 
 	@:noCompletion private function __updateDisplayObject(displayObject:DisplayObject, frameObject:FrameObject, reset:Bool = false):Void


### PR DESCRIPTION
SWF semantics define `ClipDepth > 0` as a clipping character: the character itself is not displayed, and `ClipDepth` specifies the highest depth it masks. Previously, the runtime only treated the character as a mask after finding a target object in `(depth, clipDepth]`. If no such target existed on that frame, no `mask`/`clippingLayer` assignment happened, so OpenFL rendered the clipping character normally.

The fix leaves the existing depth-range mask assignment unchanged, but also marks active `clipDepth > 0` placements as timeline masks after frame processing. This keeps clipping characters hidden even before any target child appears.
