### PR TITLE
Respect clipDepth when reusing timeline instances

### DIFF
--- a/src/swf/exporters/animate/AnimateTimeline.hx
+++ b/src/swf/exporters/animate/AnimateTimeline.hx
@@ -372,7 +372,8 @@ class AnimateTimeline extends Timeline
 						{
 							if (activeInstance.displayObject != null
 								&& activeInstance.characterID == frameObject.symbol
-								&& activeInstance.depth == frameObject.depth)
+								&& activeInstance.depth == frameObject.depth
+								&& activeInstance.clipDepth == frameObject.clipDepth)
 							{
 								// TODO: Fix duplicates in exporter
 								instance = activeInstance;

--- a/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
+++ b/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
@@ -210,7 +210,8 @@ class SymbolTimeline extends Timeline
 						{
 							if (activeInstance.displayObject != null
 								&& activeInstance.characterID == frameObject.symbol
-								&& activeInstance.depth == frameObject.depth)
+								&& activeInstance.depth == frameObject.depth
+								&& activeInstance.clipDepth == frameObject.clipDepth)
 							{
 								// TODO: Fix duplicates in exporter
 								instance = activeInstance;


### PR DESCRIPTION
This fixes a timeline instance reuse issue when the same character is placed at the same depth with a different `clipDepth`.

Previously, Animate and SWFLite timelines deduped instances by character id and depth only. However, `clipDepth` is stored on the timeline instance when it is created. If a later placement reused the same instance with a different `clipDepth`, the old mask range could be kept and masking would be applied incorrectly.

The fix includes `clipDepth` in the duplicate-instance match for both Animate and SWFLite timeline paths.

I attached a small repro project with a minimal SWF asset. The SWF places character `100` at depth `7` without `clipDepth`, then later places the same character at the same depth with `clipDepth = 11`.

[ClipDepthReuseRepro.zip](https://github.com/user-attachments/files/27248445/ClipDepthReuseRepro.zip)
