### PR TITLE
Native SWF Vector Font Extraction to XML

### DIFF
--- a/scripts/ExportFonts.hx
+++ b/scripts/ExportFonts.hx
@@ -1,0 +1,115 @@
+package;
+
+import sys.io.File;
+import sys.FileSystem;
+import swf.SWF;
+import openfl.utils.ByteArray;
+import swf.exporters.NativeFontExporter;
+import swf.exporters.SWFVectorFont;
+
+class ExportFonts
+{
+	public static function main()
+	{
+		var args = Sys.args();
+		if (args.length < 2)
+		{
+			Sys.println("Usage: haxe --run ExportFonts <input.swf> <output_folder>");
+			return;
+		}
+
+		var swfPath = args[0];
+		var outputDir = args[1];
+
+		Sys.println("Reading SWF: " + swfPath);
+
+		var rawBytes = File.getBytes(swfPath);
+
+		var bytes = ByteArray.fromBytes(rawBytes);
+
+		bytes.position = 0;
+		bytes.endian = openfl.utils.Endian.LITTLE_ENDIAN;
+
+		var swf = new SWF(bytes);
+
+		Sys.println("Extracting Vector Fonts natively...");
+		var fonts = NativeFontExporter.extract(swf);
+
+		if (!FileSystem.exists(outputDir))
+		{
+			FileSystem.createDirectory(outputDir);
+		}
+
+		var nameCount = new Map<String, Int>();
+
+		for (font in fonts)
+		{
+			var baseName = font.name.split(" ").join("_");
+			var safeName = baseName;
+
+			if (nameCount.exists(baseName))
+			{
+				var count = nameCount.get(baseName) + 1;
+				nameCount.set(baseName, count);
+				safeName = baseName + "_" + count;
+			}
+			else
+			{
+				nameCount.set(baseName, 1);
+			}
+
+			var xmlContent = generateXML(font);
+
+			var filePath = outputDir + "/" + safeName + ".xml";
+			File.saveContent(filePath, xmlContent);
+			Sys.println("Saved: " + filePath);
+		}
+
+		Sys.println("Done! Extracted " + fonts.length + " individual XML fonts.");
+	}
+
+	private static function generateXML(font:SWFVectorFont):String
+	{
+		var xml = '<?xml version="1.0" encoding="utf-8"?>\n';
+		xml += '<font name="'
+			+ font.name
+			+ '" ascent="'
+			+ font.ascent
+			+ '" descent="'
+			+ font.descent
+			+ '" leading="'
+			+ font.leading
+			+ '">\n';
+
+		for (charCode in font.glyphs.keys())
+		{
+			var glyph = font.glyphs.get(charCode);
+			xml += '\t<glyph charCode="' + charCode + '" advance="' + glyph.advance + '">\n';
+
+			var pathData = "";
+
+			for (cmd in glyph.commands)
+			{
+				switch (cmd)
+				{
+					case MoveTo(x, y):
+						pathData += 'M $x $y ';
+					case LineTo(x, y):
+						pathData += 'L $x $y ';
+					case CurveTo(cx, cy, ax, ay):
+						pathData += 'Q $cx $cy $ax $ay ';
+				}
+			}
+
+			if (StringTools.trim(pathData) != "")
+			{
+				xml += '\t\t<path d="' + StringTools.trim(pathData) + '"/>\n';
+			}
+
+			xml += '\t</glyph>\n';
+		}
+
+		xml += '</font>';
+		return xml;
+	}
+}

--- a/scripts/ExportFonts.hx
+++ b/scripts/ExportFonts.hx
@@ -15,7 +15,12 @@ class ExportFonts
 		var args = Sys.args();
 		if (args.length < 2)
 		{
-			Sys.println("Usage: haxe --run ExportFonts <input.swf> <output_folder>");
+			Sys.println("ExportFonts - Native SWF Vector Extractor\n");
+			Sys.println("Usage (Recommended - Neko):");
+			Sys.println("  1. Build: haxe -cp src -cp scripts -lib openfl -lib lime -lib format -D optional-cffi -main ExportFonts -neko export_fonts.n");
+			Sys.println("  2. Run:   neko export_fonts.n <input.swf> <output_folder>\n");
+			Sys.println("Usage (Direct/Eval - May cause memory issues on large SWFs):");
+			Sys.println("  haxe --run ExportFonts <input.swf> <output_folder>");
 			return;
 		}
 
@@ -85,25 +90,11 @@ class ExportFonts
 			var glyph = font.glyphs.get(charCode);
 			buf.add('\t<glyph charCode="$charCode" advance="${glyph.advance}">\n');
 
-			var pathBuf = new StringBuf();
-
-			for (cmd in glyph.commands)
+			if (glyph.pathData != "")
 			{
-				switch (cmd)
-				{
-					case MoveTo(x, y):
-						pathBuf.add('M $x $y ');
-					case LineTo(x, y):
-						pathBuf.add('L $x $y ');
-					case CurveTo(cx, cy, ax, ay):
-						pathBuf.add('Q $cx $cy $ax $ay ');
-				}
-			}
-
-			var pathString = StringTools.trim(pathBuf.toString());
-			if (pathString != "")
-			{
-				buf.add('\t\t<path d="$pathString"/>\n');
+				buf.add('\t\t<path d="');
+				buf.add(glyph.pathData);
+				buf.add('"/>\n');
 			}
 
 			buf.add('\t</glyph>\n');

--- a/scripts/ExportFonts.hx
+++ b/scripts/ExportFonts.hx
@@ -2,6 +2,7 @@ package;
 
 import sys.io.File;
 import sys.FileSystem;
+import haxe.io.Path;
 import swf.SWF;
 import openfl.utils.ByteArray;
 import swf.exporters.NativeFontExporter;
@@ -21,10 +22,14 @@ class ExportFonts
 		var swfPath = args[0];
 		var outputDir = args[1];
 
+		if (!FileSystem.exists(swfPath))
+		{
+			Sys.println("Error: Input SWF file not found at path: " + swfPath);
+			return;
+		}
+
 		Sys.println("Reading SWF: " + swfPath);
-
 		var rawBytes = File.getBytes(swfPath);
-
 		var bytes = ByteArray.fromBytes(rawBytes);
 
 		bytes.position = 0;
@@ -60,7 +65,7 @@ class ExportFonts
 
 			var xmlContent = generateXML(font);
 
-			var filePath = outputDir + "/" + safeName + ".xml";
+			var filePath = Path.join([outputDir, safeName + ".xml"]);
 			File.saveContent(filePath, xmlContent);
 			Sys.println("Saved: " + filePath);
 		}
@@ -70,46 +75,41 @@ class ExportFonts
 
 	private static function generateXML(font:SWFVectorFont):String
 	{
-		var xml = '<?xml version="1.0" encoding="utf-8"?>\n';
-		xml += '<font name="'
-			+ font.name
-			+ '" ascent="'
-			+ font.ascent
-			+ '" descent="'
-			+ font.descent
-			+ '" leading="'
-			+ font.leading
-			+ '">\n';
+		var buf = new StringBuf();
+
+		buf.add('<?xml version="1.0" encoding="utf-8"?>\n');
+		buf.add('<font name="${font.name}" ascent="${font.ascent}" descent="${font.descent}" leading="${font.leading}">\n');
 
 		for (charCode in font.glyphs.keys())
 		{
 			var glyph = font.glyphs.get(charCode);
-			xml += '\t<glyph charCode="' + charCode + '" advance="' + glyph.advance + '">\n';
+			buf.add('\t<glyph charCode="$charCode" advance="${glyph.advance}">\n');
 
-			var pathData = "";
+			var pathBuf = new StringBuf();
 
 			for (cmd in glyph.commands)
 			{
 				switch (cmd)
 				{
 					case MoveTo(x, y):
-						pathData += 'M $x $y ';
+						pathBuf.add('M $x $y ');
 					case LineTo(x, y):
-						pathData += 'L $x $y ';
+						pathBuf.add('L $x $y ');
 					case CurveTo(cx, cy, ax, ay):
-						pathData += 'Q $cx $cy $ax $ay ';
+						pathBuf.add('Q $cx $cy $ax $ay ');
 				}
 			}
 
-			if (StringTools.trim(pathData) != "")
+			var pathString = StringTools.trim(pathBuf.toString());
+			if (pathString != "")
 			{
-				xml += '\t\t<path d="' + StringTools.trim(pathData) + '"/>\n';
+				buf.add('\t\t<path d="$pathString"/>\n');
 			}
 
-			xml += '\t</glyph>\n';
+			buf.add('\t</glyph>\n');
 		}
 
-		xml += '</font>';
-		return xml;
+		buf.add('</font>');
+		return buf.toString();
 	}
 }

--- a/src/swf/exporters/NativeFontExporter.hx
+++ b/src/swf/exporters/NativeFontExporter.hx
@@ -62,7 +62,7 @@ class NativeFontExporter
 				var shapeExporter = new ShapeCommandExporter(null);
 				shape.export(shapeExporter);
 
-				var glyphCommands = convertCommands(shapeExporter.commands, scale);
+				var finalSvgPath = generateSVGPath(shapeExporter.commands, scale);
 
 				var charAdvance = 0.0;
 				if (fontTag.hasLayout && fontTag.fontAdvanceTable != null && i < fontTag.fontAdvanceTable.length)
@@ -71,7 +71,7 @@ class NativeFontExporter
 				}
 
 				font.glyphs.set(charCode, {
-					commands: glyphCommands,
+					pathData: finalSvgPath,
 					advance: charAdvance
 				});
 			}
@@ -80,28 +80,41 @@ class NativeFontExporter
 		return font;
 	}
 
-	private static function convertCommands(openflCommands:Array<ShapeCommand>, scale:Float):Array<GlyphCommand>
+	private static function generateSVGPath(commands:Array<ShapeCommand>, scale:Float):String
 	{
-		var result = new Array<GlyphCommand>();
+		if (commands == null || commands.length == 0) return "";
 
-		for (cmd in openflCommands)
+		var buf = new StringBuf();
+		for (cmd in commands)
 		{
 			switch (cmd)
 			{
 				case MoveTo(x, y):
-					result.push(GlyphCommand.MoveTo(roundFloat(x / scale), roundFloat(y / scale)));
-
+					buf.add("M ");
+					buf.add(roundFloat(x / scale));
+					buf.add(" ");
+					buf.add(roundFloat(y / scale));
+					buf.add(" ");
 				case LineTo(x, y):
-					result.push(GlyphCommand.LineTo(roundFloat(x / scale), roundFloat(y / scale)));
-
+					buf.add("L ");
+					buf.add(roundFloat(x / scale));
+					buf.add(" ");
+					buf.add(roundFloat(y / scale));
+					buf.add(" ");
 				case CurveTo(cx, cy, ax, ay):
-					result.push(GlyphCommand.CurveTo(roundFloat(cx / scale), roundFloat(cy / scale), roundFloat(ax / scale), roundFloat(ay / scale)));
-
+					buf.add("Q ");
+					buf.add(roundFloat(cx / scale));
+					buf.add(" ");
+					buf.add(roundFloat(cy / scale));
+					buf.add(" ");
+					buf.add(roundFloat(ax / scale));
+					buf.add(" ");
+					buf.add(roundFloat(ay / scale));
+					buf.add(" ");
 				default:
 			}
 		}
-
-		return result;
+		return StringTools.trim(buf.toString());
 	}
 
 	private static inline function roundFloat(val:Float):Float

--- a/src/swf/exporters/NativeFontExporter.hx
+++ b/src/swf/exporters/NativeFontExporter.hx
@@ -42,9 +42,9 @@ class NativeFontExporter
 
 		if (fontTag.hasLayout)
 		{
-			font.ascent = fontTag.ascent / scale;
-			font.descent = fontTag.descent / scale;
-			font.leading = fontTag.leading / scale;
+			font.ascent = roundFloat(fontTag.ascent / scale);
+			font.descent = roundFloat(fontTag.descent / scale);
+			font.leading = roundFloat(fontTag.leading / scale);
 		}
 
 		var shapeTable = fontTag.glyphShapeTable;
@@ -67,7 +67,7 @@ class NativeFontExporter
 				var charAdvance = 0.0;
 				if (fontTag.hasLayout && fontTag.fontAdvanceTable != null && i < fontTag.fontAdvanceTable.length)
 				{
-					charAdvance = fontTag.fontAdvanceTable[i] / scale;
+					charAdvance = roundFloat(fontTag.fontAdvanceTable[i] / scale);
 				}
 
 				font.glyphs.set(charCode, {
@@ -89,18 +89,23 @@ class NativeFontExporter
 			switch (cmd)
 			{
 				case MoveTo(x, y):
-					result.push(GlyphCommand.MoveTo(x / scale, y / scale));
+					result.push(GlyphCommand.MoveTo(roundFloat(x / scale), roundFloat(y / scale)));
 
 				case LineTo(x, y):
-					result.push(GlyphCommand.LineTo(x / scale, y / scale));
+					result.push(GlyphCommand.LineTo(roundFloat(x / scale), roundFloat(y / scale)));
 
 				case CurveTo(cx, cy, ax, ay):
-					result.push(GlyphCommand.CurveTo(cx / scale, cy / scale, ax / scale, ay / scale));
+					result.push(GlyphCommand.CurveTo(roundFloat(cx / scale), roundFloat(cy / scale), roundFloat(ax / scale), roundFloat(ay / scale)));
 
 				default:
 			}
 		}
 
 		return result;
+	}
+
+	private static inline function roundFloat(val:Float):Float
+	{
+		return Math.round(val * 10000.0) / 10000.0;
 	}
 }

--- a/src/swf/exporters/NativeFontExporter.hx
+++ b/src/swf/exporters/NativeFontExporter.hx
@@ -6,6 +6,9 @@ import swf.tags.TagDefineFont3;
 import swf.exporters.ShapeCommandExporter;
 import swf.exporters.core.ShapeCommand;
 import swf.exporters.SWFVectorFont;
+import sys.thread.Thread;
+import sys.thread.Mutex;
+import sys.thread.Lock;
 
 class NativeFontExporter
 {
@@ -14,14 +17,37 @@ class NativeFontExporter
 	public static function extract(swf:SWF):Array<SWFVectorFont>
 	{
 		var exportedFonts = new Array<SWFVectorFont>();
+		var fontTagsToProcess = new Array<TagDefineFont2>();
 
 		for (tag in swf.data.tags)
 		{
 			if (Std.isOfType(tag, TagDefineFont2))
 			{
-				var fontTag:TagDefineFont2 = cast tag;
-				exportedFonts.push(processFontTag(fontTag));
+				fontTagsToProcess.push(cast tag);
 			}
+		}
+
+		if (fontTagsToProcess.length == 0) return exportedFonts;
+
+		var mutex = new Mutex();
+		var lock = new Lock();
+
+		for (fontTag in fontTagsToProcess)
+		{
+			Thread.create(function()
+			{
+				var parsedFont = processFontTag(fontTag);
+
+				mutex.acquire();
+				exportedFonts.push(parsedFont);
+				mutex.release();
+				lock.release();
+			});
+		}
+
+		for (i in 0...fontTagsToProcess.length)
+		{
+			lock.wait();
 		}
 
 		return exportedFonts;

--- a/src/swf/exporters/NativeFontExporter.hx
+++ b/src/swf/exporters/NativeFontExporter.hx
@@ -1,0 +1,106 @@
+package swf.exporters;
+
+import swf.SWF;
+import swf.tags.TagDefineFont2;
+import swf.tags.TagDefineFont3;
+import swf.exporters.ShapeCommandExporter;
+import swf.exporters.core.ShapeCommand;
+import swf.exporters.SWFVectorFont;
+
+class NativeFontExporter
+{
+	private static inline var TWIPS:Float = 20.0;
+
+	public static function extract(swf:SWF):Array<SWFVectorFont>
+	{
+		var exportedFonts = new Array<SWFVectorFont>();
+
+		for (tag in swf.data.tags)
+		{
+			if (Std.isOfType(tag, TagDefineFont2))
+			{
+				var fontTag:TagDefineFont2 = cast tag;
+				exportedFonts.push(processFontTag(fontTag));
+			}
+		}
+
+		return exportedFonts;
+	}
+
+	private static function processFontTag(fontTag:TagDefineFont2):SWFVectorFont
+	{
+		var isFont3 = Std.isOfType(fontTag, TagDefineFont3);
+		var scale = isFont3 ? (TWIPS * 20.0) : TWIPS;
+
+		var font:SWFVectorFont = {
+			name: fontTag.fontName != null ? fontTag.fontName : "Unknown_" + fontTag.characterId,
+			ascent: 0,
+			descent: 0,
+			leading: 0,
+			glyphs: new Map<Int, GlyphData>()
+		};
+
+		if (fontTag.hasLayout)
+		{
+			font.ascent = fontTag.ascent / scale;
+			font.descent = fontTag.descent / scale;
+			font.leading = fontTag.leading / scale;
+		}
+
+		var shapeTable = fontTag.glyphShapeTable;
+		var codeTable = fontTag.codeTable;
+
+		if (shapeTable != null && codeTable != null)
+		{
+			for (i in 0...shapeTable.length)
+			{
+				if (i >= codeTable.length) break;
+
+				var charCode = codeTable[i];
+				var shape = shapeTable[i];
+
+				var shapeExporter = new ShapeCommandExporter(null);
+				shape.export(shapeExporter);
+
+				var glyphCommands = convertCommands(shapeExporter.commands, scale);
+
+				var charAdvance = 0.0;
+				if (fontTag.hasLayout && fontTag.fontAdvanceTable != null && i < fontTag.fontAdvanceTable.length)
+				{
+					charAdvance = fontTag.fontAdvanceTable[i] / scale;
+				}
+
+				font.glyphs.set(charCode, {
+					commands: glyphCommands,
+					advance: charAdvance
+				});
+			}
+		}
+
+		return font;
+	}
+
+	private static function convertCommands(openflCommands:Array<ShapeCommand>, scale:Float):Array<GlyphCommand>
+	{
+		var result = new Array<GlyphCommand>();
+
+		for (cmd in openflCommands)
+		{
+			switch (cmd)
+			{
+				case MoveTo(x, y):
+					result.push(GlyphCommand.MoveTo(x / scale, y / scale));
+
+				case LineTo(x, y):
+					result.push(GlyphCommand.LineTo(x / scale, y / scale));
+
+				case CurveTo(cx, cy, ax, ay):
+					result.push(GlyphCommand.CurveTo(cx / scale, cy / scale, ax / scale, ay / scale));
+
+				default:
+			}
+		}
+
+		return result;
+	}
+}

--- a/src/swf/exporters/SWFVectorFont.hx
+++ b/src/swf/exporters/SWFVectorFont.hx
@@ -1,0 +1,23 @@
+package swf.exporters;
+
+enum GlyphCommand
+{
+	MoveTo(x:Float, y:Float);
+	LineTo(x:Float, y:Float);
+	CurveTo(cx:Float, cy:Float, ax:Float, ay:Float);
+}
+
+typedef GlyphData =
+{
+	var commands:Array<GlyphCommand>;
+	var advance:Float;
+}
+
+typedef SWFVectorFont =
+{
+	var name:String;
+	var ascent:Float;
+	var descent:Float;
+	var leading:Float;
+	var glyphs:Map<Int, GlyphData>;
+}

--- a/src/swf/exporters/SWFVectorFont.hx
+++ b/src/swf/exporters/SWFVectorFont.hx
@@ -1,15 +1,8 @@
 package swf.exporters;
 
-enum GlyphCommand
-{
-	MoveTo(x:Float, y:Float);
-	LineTo(x:Float, y:Float);
-	CurveTo(cx:Float, cy:Float, ax:Float, ay:Float);
-}
-
 typedef GlyphData =
 {
-	var commands:Array<GlyphCommand>;
+	var pathData:String;
 	var advance:Float;
 }
 


### PR DESCRIPTION
## Description
This PR introduces a zero-dependency native Haxe pipeline for extracting embedded vector fonts directly from parsed SWF files into XML. 

### The Motivation
Using external TTF compilers (or Java-based tools) during the build process is cumbersome. Furthermore, relying on standard OpenFL `TextFields` to render these generated `.ttf` files on native targets (especially Linux via FreeType) often results in inaccurate baseline alignments and slightly off-centered text compared to Flash. 

By extracting the raw vector commands and metrics directly, developers can write their own custom text renderers (using `graphics.drawPath()`) to achieve 100% pixel-perfect text rendering across all platforms, completely bypassing OS-level text rendering quirks.

### Technical Implementation
The extraction pipeline bypasses the complex `.ttf` generation and hooks directly into `ShapeCommandExporter` to extract `DefineFont2` and `DefineFont3` geometries.

1. **Direct-to-String SVG Path Generation:** Instead of generating arrays of `GlyphCommand` enums and parsing them later, the SVG commands (`M`, `L`, `Q`) are generated on-the-fly using `StringBuf`.
2. **Multithreading (`sys.thread`):** Native extraction processes multiple font tags concurrently using background threads with `Mutex`/`Lock` synchronization. This scales perfectly on large SWFs with multiple embedded fonts.
3. **Coordinate Rounding:** TWIPS coordinates scaled to pixels often result in infinite floating-point artifacts (e.g., `1.33333333333333`). Coordinates are rounded to 4 decimal places, which maintains flawless visual fidelity while significantly reducing the output XML file size.
4. **Cross-Platform Safety:** Paths are constructed using `haxe.io.Path.join()` and we handle duplicate embedded font names by appending numeric suffixes (`FontName_2.xml`).

### Testing
I have built a separate OpenFL [test application](https://github.com/user-attachments/files/27906366/FontTesting.zip) that parses these generated XMLs. It uses pre-calculated `openfl.Vector<Int>` and `Vector<Float>` structures at runtime to pass the metrics directly to `graphics.moveTo()` and `curveTo()`. The results demonstrate perfectly crisp, baseline-accurate rendering on native Linux targets.

**Usage via Neko:**
```bash
haxe -cp src -cp scripts -lib openfl -lib lime -lib format -D optional-cffi -main ExportFonts -neko export_fonts.n
neko export_fonts.n <input.swf> <output_folder>