### PR TITLE
Preserve lineGradientStyle in SWF shape exports

### DIFF
--- a/src/swf/exporters/AnimateLibraryExporter.hx
+++ b/src/swf/exporters/AnimateLibraryExporter.hx
@@ -613,6 +613,19 @@ class AnimateLibraryExporter
 							]);
 						}
 
+					case LineGradientStyle(type, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+						commands = commands.concat([
+							SWFShapeCommandType.LINE_GRADIENT_STYLE,
+							type,
+							colors,
+							alphas,
+							ratios,
+							serializeMatrix(matrix),
+							spreadMethod,
+							interpolationMethod,
+							focalPointRatio
+						]);
+
 					case BeginFill(color, alpha):
 						commands = commands.concat([SWFShapeCommandType.BEGIN_FILL, color, alpha]);
 
@@ -991,6 +1004,19 @@ class AnimateLibraryExporter
 											miterLimit
 										]);
 									}
+
+								case LineGradientStyle(type, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+									commands = commands.concat([
+										SWFShapeCommandType.LINE_GRADIENT_STYLE,
+										type,
+										colors,
+										alphas,
+										ratios,
+										serializeMatrix(matrix),
+										spreadMethod,
+										interpolationMethod,
+										focalPointRatio
+									]);
 
 								case BeginFill(color, alpha):
 									commands = commands.concat([SWFShapeCommandType.BEGIN_FILL, color, alpha]);
@@ -1541,6 +1567,7 @@ private #if (haxe_ver >= 4.0) enum #end abstract SWFShapeCommandType(Int) from I
 	public var LINE_STYLE = 6;
 	public var LINE_TO = 7;
 	public var MOVE_TO = 8;
+	public var LINE_GRADIENT_STYLE = 9;
 }
 
 #if (haxe_ver < 4.0) @:enum #end

--- a/src/swf/exporters/ShapeCommandExporter.hx
+++ b/src/swf/exporters/ShapeCommandExporter.hx
@@ -69,6 +69,12 @@ class ShapeCommandExporter extends DefaultShapeExporter
 		commands.push(LineStyle(thickness, color, alpha, pixelHinting, scaleMode, startCaps, /*endCaps,*/ joints, miterLimit));
 	}
 
+	override public function lineGradientStyle(type:GradientType, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix = null,
+			spreadMethod:SpreadMethod = null, interpolationMethod:InterpolationMethod = null, focalPointRatio:Float = 0):Void
+	{
+		commands.push(LineGradientStyle(type, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio));
+	}
+
 	override public function moveTo(x:Float, y:Float):Void
 	{
 		commands.push(MoveTo(x, y));

--- a/src/swf/exporters/animate/AnimateLibrary.hx
+++ b/src/swf/exporters/animate/AnimateLibrary.hx
@@ -662,6 +662,10 @@ import openfl.filters.GlowFilter;
 								commands.push(LineStyle(data[i + 1], data[i + 2], data[i + 3], data[i + 4], data[i + 5], data[i + 6], data[i + 7],
 									data[i + 8]));
 								i += 9;
+							case LINE_GRADIENT_STYLE:
+								commands.push(LineGradientStyle(data[i + 1], data[i + 2], data[i + 3], data[i + 4], __parseMatrix(data[i + 5]), data[i + 6],
+									data[i + 7], data[i + 8]));
+								i += 9;
 							case LINE_TO:
 								commands.push(LineTo(__pixel(data[i + 1]), __pixel(data[i + 2])));
 								i += 3;
@@ -718,6 +722,10 @@ import openfl.filters.GlowFilter;
 					i++;
 				case LINE_STYLE:
 					commands.push(LineStyle(data[i + 1], data[i + 2], data[i + 3], data[i + 4], data[i + 5], data[i + 6], data[i + 7], data[i + 8]));
+					i += 9;
+				case LINE_GRADIENT_STYLE:
+					commands.push(LineGradientStyle(data[i + 1], data[i + 2], data[i + 3], data[i + 4], __parseMatrix(data[i + 5]), data[i + 6],
+						data[i + 7], data[i + 8]));
 					i += 9;
 				case LINE_TO:
 					commands.push(LineTo(__pixel(data[i + 1]), __pixel(data[i + 2])));
@@ -819,6 +827,7 @@ import openfl.filters.GlowFilter;
 	public var LINE_STYLE = 6;
 	public var LINE_TO = 7;
 	public var MOVE_TO = 8;
+	public var LINE_GRADIENT_STYLE = 9;
 }
 
 #if (haxe_ver >= 4.0) enum #else @:enum #end abstract SWFSymbolType(Int) from Int to Int

--- a/src/swf/exporters/animate/AnimateShapeCommand.hx
+++ b/src/swf/exporters/animate/AnimateShapeCommand.hx
@@ -19,6 +19,8 @@ enum AnimateShapeCommand
 	EndFill;
 	LineStyle(thickness:Null<Float>, color:Null<Int>, alpha:Null<Float>, pixelHinting:Null<Bool>, scaleMode:Null<Int> /*LineScaleMode*/,
 		caps:Null<Int> /*CapsStyle*/, joints:Null<Int> /*JointStyle*/, miterLimit:Null<Float>);
+	LineGradientStyle(fillType:Null<Int> /*GradientType*/, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix,
+		spreadMethod:Null<Int> /*SpreadMethod*/, interpolationMethod:Null<Int> /*InterpolationMethod*/, focalPointRatio:Float);
 	LineTo(x:Float, y:Float);
 	MoveTo(x:Float, y:Float);
 }

--- a/src/swf/exporters/animate/AnimateShapeSymbol.hx
+++ b/src/swf/exporters/animate/AnimateShapeSymbol.hx
@@ -83,6 +83,10 @@ class AnimateShapeSymbol extends AnimateSymbol
 						graphics.lineStyle();
 					}
 
+				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					graphics.lineGradientStyle(GradientType.fromInt(fillType), colors, alphas, ratios, matrix, SpreadMethod.fromInt(spreadMethod),
+						InterpolationMethod.fromInt(interpolationMethod), focalPointRatio);
+
 				case LineTo(x, y):
 					graphics.lineTo(x, y);
 

--- a/src/swf/exporters/animate/AnimateShapeSymbol.hx
+++ b/src/swf/exporters/animate/AnimateShapeSymbol.hx
@@ -84,6 +84,9 @@ class AnimateShapeSymbol extends AnimateSymbol
 					}
 
 				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					#if flash
+					var colors:Array<UInt> = cast colors;
+					#end
 					graphics.lineGradientStyle(GradientType.fromInt(fillType), colors, alphas, ratios, matrix, SpreadMethod.fromInt(spreadMethod),
 						InterpolationMethod.fromInt(interpolationMethod), focalPointRatio);
 

--- a/src/swf/exporters/core/ShapeCommand.hx
+++ b/src/swf/exporters/core/ShapeCommand.hx
@@ -25,6 +25,8 @@ enum ShapeCommand
 	EndFill;
 	LineStyle(thickness:Null<Float>, color:Null<Int>, alpha:Null<Float>, pixelHinting:Null<Bool>, scaleMode:LineScaleMode, caps:CapsStyle, joints:JointStyle,
 		miterLimit:Null<Float>);
+	LineGradientStyle(fillType:GradientType, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, matrix:Matrix, spreadMethod:SpreadMethod,
+		interpolationMethod:InterpolationMethod, focalPointRatio:Float);
 	LineTo(x:Float, y:Float);
 	MoveTo(x:Float, y:Float);
 }

--- a/src/swf/exporters/swflite/ShapeSymbol.hx
+++ b/src/swf/exporters/swflite/ShapeSymbol.hx
@@ -83,6 +83,9 @@ class ShapeSymbol extends SWFSymbol
 						graphics.lineStyle();
 					}
 
+				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
+
 				case LineTo(x, y):
 					graphics.lineTo(x, y);
 

--- a/src/swf/exporters/swflite/ShapeSymbol.hx
+++ b/src/swf/exporters/swflite/ShapeSymbol.hx
@@ -84,6 +84,9 @@ class ShapeSymbol extends SWFSymbol
 					}
 
 				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					#if flash
+					var colors:Array<UInt> = cast colors;
+					#end
 					graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
 
 				case LineTo(x, y):

--- a/src/swf/runtime/MorphShape.hx
+++ b/src/swf/runtime/MorphShape.hx
@@ -70,6 +70,9 @@ class MorphShape extends openfl.display.Shape
 					}
 
 				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					#if flash
+					var colors:Array<UInt> = cast colors;
+					#end
 					graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
 
 				case LineTo(x, y):

--- a/src/swf/runtime/MorphShape.hx
+++ b/src/swf/runtime/MorphShape.hx
@@ -69,6 +69,9 @@ class MorphShape extends openfl.display.Shape
 						graphics.lineStyle();
 					}
 
+				case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+					graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
+
 				case LineTo(x, y):
 					graphics.lineTo(x, y);
 

--- a/src/swf/runtime/Shape.hx
+++ b/src/swf/runtime/Shape.hx
@@ -49,6 +49,9 @@ class Shape extends openfl.display.Shape
 							graphics.lineStyle();
 						}
 
+					case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+						graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
+
 					case LineTo(x, y):
 						graphics.lineTo(x, y);
 

--- a/src/swf/runtime/Shape.hx
+++ b/src/swf/runtime/Shape.hx
@@ -50,6 +50,9 @@ class Shape extends openfl.display.Shape
 						}
 
 					case LineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio):
+						#if flash
+						var colors:Array<UInt> = cast colors;
+						#end
 						graphics.lineGradientStyle(fillType, colors, alphas, ratios, matrix, spreadMethod, interpolationMethod, focalPointRatio);
 
 					case LineTo(x, y):


### PR DESCRIPTION
`SWFShape.export()` already emits `lineGradientStyle(...)` for `LINESTYLE2` records that use a gradient fill, but `ShapeCommandExporter` inherited the no-op implementation from `DefaultShapeExporter`. As a result, Animate/SWFLite exports kept the base `lineStyle` but lost the gradient stroke data.

This adds `LineGradientStyle` to shape commands and wires it through:
- `ShapeCommandExporter`
- Animate serialization/deserialization
- Animate shape rendering
- SWFLite shape rendering

[SWFLineGradientStyleExportRepro.zip](https://github.com/user-attachments/files/28412603/SWFLineGradientStyleExportRepro.zip)