### PR TITLE
Adding support for GradientGlow and GradientBevel filters 

### DIFF
--- a/src/swf/data/filters/FilterGradientBevel.hx
+++ b/src/swf/data/filters/FilterGradientBevel.hx
@@ -1,12 +1,11 @@
 package swf.data.filters;
 
 import swf.utils.ColorUtils;
+import swf.exporters.core.FilterType;
 import openfl.filters.BitmapFilter;
+import openfl.filters.GradientBevelFilter;
 import openfl.filters.BitmapFilterType;
-#if flash
-import flash.filters.GradientBevelFilter; // Not supported on native yet
 
-#end
 class FilterGradientBevel extends FilterGradientGlow implements IFilter
 {
 	public function new(id:Int)
@@ -16,38 +15,36 @@ class FilterGradientBevel extends FilterGradientGlow implements IFilter
 
 	override private function get_filter():BitmapFilter
 	{
-		var gradientGlowColors:Array<Int> = [];
-		var gradientGlowAlphas:Array<Float> = [];
-		var gradientGlowRatios:Array<Float> = [];
-		for (i in 0...numColors)
-		{
-			gradientGlowColors.push(ColorUtils.rgb(gradientColors[i]));
-			gradientGlowAlphas.push(ColorUtils.alpha(gradientColors[i]));
-			gradientGlowRatios.push(gradientRatios[i]);
-		}
-		#if flash
-		var filterType:BitmapFilterType;
-		#else
-		var filterType:String;
-		#end
-		if (onTop)
-		{
-			filterType = BitmapFilterType.FULL;
-		}
-		else
-		{
-			filterType = (innerShadow) ? BitmapFilterType.INNER : BitmapFilterType.OUTER;
-		}
-		#if flash
-		return new GradientBevelFilter(distance, angle, gradientGlowColors, gradientGlowAlphas, gradientGlowRatios, blurX, blurY, strength, passes,
-			Std.string(filterType), knockout);
-		#else
 		#if ((cpp || neko) && openfl_legacy)
 		return new BitmapFilter("");
 		#else
-		return new BitmapFilter();
+		var gradientBevelColors:Array<Int> = [];
+		var gradientBevelAlphas:Array<Float> = [];
+		var gradientBevelRatios:Array<Int> = [];
+		for (i in 0...numColors)
+		{
+			gradientBevelColors.push(ColorUtils.rgb(gradientColors[i]));
+			gradientBevelAlphas.push(ColorUtils.alpha(gradientColors[i]));
+			gradientBevelRatios.push(gradientRatios[i]);
+		}
+		var filterType = getBitmapFilterType();
+		return new GradientBevelFilter(distance, angle * 180 / Math.PI, gradientBevelColors, gradientBevelAlphas, gradientBevelRatios, blurX, blurY, strength, passes, filterType, knockout);
 		#end
-		#end
+	}
+
+	override private function get_type():FilterType
+	{
+		var colors:Array<Int> = [];
+		var alphas:Array<Float> = [];
+		var ratios:Array<Int> = [];
+		for (i in 0...numColors)
+		{
+			colors.push(ColorUtils.rgb(gradientColors[i]));
+			alphas.push(ColorUtils.alpha(gradientColors[i]));
+			ratios.push(gradientRatios[i]);
+		}
+		var filterType = getBitmapFilterType();
+		return GradientBevelFilter(distance, angle * 180 / Math.PI, colors, alphas, ratios, blurX, blurY, strength, passes, filterType, knockout);
 	}
 
 	override public function clone():IFilter
@@ -69,7 +66,7 @@ class FilterGradientBevel extends FilterGradientGlow implements IFilter
 		filter.distance = distance;
 		filter.strength = strength;
 		filter.passes = passes;
-		filter.innerShadow = innerShadow;
+		filter.inner = inner;
 		filter.knockout = knockout;
 		filter.compositeSource = compositeSource;
 		filter.onTop = onTop;

--- a/src/swf/data/filters/FilterGradientGlow.hx
+++ b/src/swf/data/filters/FilterGradientGlow.hx
@@ -3,12 +3,11 @@ package swf.data.filters;
 import swf.SWFData;
 import swf.utils.ColorUtils;
 import swf.utils.StringUtils;
+import swf.exporters.core.FilterType;
 import openfl.filters.BitmapFilter;
+import openfl.filters.GradientGlowFilter;
 import openfl.filters.BitmapFilterType;
-#if flash
-import flash.filters.GradientGlowFilter; // Not supported on native yet
 
-#end
 class FilterGradientGlow extends Filter implements IFilter
 {
 	public var numColors:Int;
@@ -17,7 +16,7 @@ class FilterGradientGlow extends Filter implements IFilter
 	public var angle:Float;
 	public var distance:Float;
 	public var strength:Float;
-	public var innerShadow:Bool;
+	public var inner:Bool;
 	public var knockout:Bool;
 	public var compositeSource:Bool;
 	public var onTop:Bool;
@@ -35,38 +34,36 @@ class FilterGradientGlow extends Filter implements IFilter
 
 	override private function get_filter():BitmapFilter
 	{
+		#if ((cpp || neko) && openfl_legacy)
+		return new BitmapFilter("");
+		#else
 		var gradientGlowColors:Array<Int> = [];
 		var gradientGlowAlphas:Array<Float> = [];
-		var gradientGlowRatios:Array<Float> = [];
+		var gradientGlowRatios:Array<Int> = [];
 		for (i in 0...numColors)
 		{
 			gradientGlowColors.push(ColorUtils.rgb(gradientColors[i]));
 			gradientGlowAlphas.push(ColorUtils.alpha(gradientColors[i]));
 			gradientGlowRatios.push(gradientRatios[i]);
 		}
-		#if flash
-		var filterType:BitmapFilterType;
-		#else
-		var filterType:String;
+		var filterType = getBitmapFilterType();
+		return new GradientGlowFilter(distance, angle * 180 / Math.PI, gradientGlowColors, gradientGlowAlphas, gradientGlowRatios, blurX, blurY, strength, passes, filterType, knockout);
 		#end
-		if (onTop)
+	}
+
+	override private function get_type():FilterType
+	{
+		var colors:Array<Int> = [];
+		var alphas:Array<Float> = [];
+		var ratios:Array<Int> = [];
+		for (i in 0...numColors)
 		{
-			filterType = BitmapFilterType.FULL;
+			colors.push(ColorUtils.rgb(gradientColors[i]));
+			alphas.push(ColorUtils.alpha(gradientColors[i]));
+			ratios.push(gradientRatios[i]);
 		}
-		else
-		{
-			filterType = (innerShadow) ? BitmapFilterType.INNER : BitmapFilterType.OUTER;
-		}
-		#if flash
-		return new GradientGlowFilter(distance, angle * 180 / Math.PI, gradientGlowColors, gradientGlowAlphas, gradientGlowRatios, blurX, blurY, strength,
-			passes, filterType, knockout);
-		#else
-		#if ((cpp || neko) && openfl_legacy)
-		return new BitmapFilter("");
-		#else
-		return new BitmapFilter();
-		#end
-		#end
+		var filterType = getBitmapFilterType();
+		return GradientGlowFilter(distance, angle * 180 / Math.PI, colors, alphas, ratios, blurX, blurY, strength, passes, filterType, knockout);
 	}
 
 	override public function parse(data:SWFData):Void
@@ -87,7 +84,7 @@ class FilterGradientGlow extends Filter implements IFilter
 		distance = data.readFIXED();
 		strength = data.readFIXED8();
 		var flags:Int = data.readUI8();
-		innerShadow = ((flags & 0x80) != 0);
+		inner = ((flags & 0x80) != 0);
 		knockout = ((flags & 0x40) != 0);
 		compositeSource = ((flags & 0x20) != 0);
 		onTop = ((flags & 0x10) != 0);
@@ -112,7 +109,7 @@ class FilterGradientGlow extends Filter implements IFilter
 		data.writeFIXED(distance);
 		data.writeFIXED8(strength);
 		var flags:Int = (passes & 0x0f);
-		if (innerShadow)
+		if (inner)
 		{
 			flags |= 0x80;
 		}
@@ -150,11 +147,16 @@ class FilterGradientGlow extends Filter implements IFilter
 		filter.distance = distance;
 		filter.strength = strength;
 		filter.passes = passes;
-		filter.innerShadow = innerShadow;
+		filter.inner = inner;
 		filter.knockout = knockout;
 		filter.compositeSource = compositeSource;
 		filter.onTop = onTop;
 		return filter;
+	}
+
+	private  function getBitmapFilterType()
+	{
+		return onTop ? BitmapFilterType.FULL : (inner ? BitmapFilterType.INNER : BitmapFilterType.OUTER);
 	}
 
 	override public function toString(indent:Int = 0):String
@@ -163,7 +165,7 @@ class FilterGradientGlow extends Filter implements IFilter
 		var str:String = "[" + filterName + "] " + "BlurX: " + blurX + ", " + "BlurY: " + blurY + ", " + "Angle: " + angle + ", " + "Distance: " + distance
 			+ ", " + "Strength: " + strength + ", " + "Passes: " + passes;
 		var flags:Array<String> = [];
-		if (innerShadow)
+		if (inner)
 		{
 			flags.push("InnerShadow");
 		}

--- a/src/swf/exporters/AnimateLibraryExporter.hx
+++ b/src/swf/exporters/AnimateLibraryExporter.hx
@@ -1442,6 +1442,38 @@ class AnimateLibraryExporter
 							inner,
 							knockout
 						]);
+
+					case GradientGlowFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						result.push([
+							SWFFilterType.GRADIENT_GLOW,
+							distance,
+							angle,
+							colors,
+							alphas,
+							ratios,
+							blurX,
+							blurY,
+							strength,
+							quality,
+							type,
+							knockout
+						]);
+
+					case GradientBevelFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						result.push([
+							SWFFilterType.GRADIENT_BEVEL,
+							distance,
+							angle,
+							colors,
+							alphas,
+							ratios,
+							blurX,
+							blurY,
+							strength,
+							quality,
+							type,
+							knockout
+						]);
 				}
 				// filterClasses.set (Type.getClassName (Type.getClass (surfaceFilter.filter)), true);
 			}
@@ -1562,5 +1594,6 @@ private #if (haxe_ver >= 4.0) enum #end abstract SWFFilterType(Int) from Int to 
 	public var COLOR_MATRIX = 1;
 	public var DROP_SHADOW = 2;
 	public var GLOW = 3;
-	// TODO: More
+	public var GRADIENT_GLOW = 4;
+	public var GRADIENT_BEVEL = 5;
 }

--- a/src/swf/exporters/animate/AnimateLibrary.hx
+++ b/src/swf/exporters/animate/AnimateLibrary.hx
@@ -603,6 +603,14 @@ import openfl.filters.GlowFilter;
 				case 3:
 					result.push(FilterType.GlowFilter(filter[1], filter[2], filter[3], filter[4], filter[5], filter[6], filter[7], filter[8]));
 
+				case 4:
+					result.push(FilterType.GradientGlowFilter(filter[1], filter[2], filter[3], filter[4], filter[5], filter[6], filter[7], filter[8],
+						filter[9], filter[10], filter[11]));
+
+				case 5:
+					result.push(FilterType.GradientBevelFilter(filter[1], filter[2], filter[3], filter[4], filter[5], filter[6], filter[7], filter[8],
+						filter[9], filter[10], filter[11]));
+
 				default:
 			}
 		}

--- a/src/swf/exporters/animate/AnimateTimeline.hx
+++ b/src/swf/exporters/animate/AnimateTimeline.hx
@@ -17,6 +17,8 @@ import openfl.filters.ConvolutionFilter;
 import openfl.filters.DisplacementMapFilter;
 import openfl.filters.DropShadowFilter;
 import openfl.filters.GlowFilter;
+import openfl.filters.GradientGlowFilter;
+import openfl.filters.GradientBevelFilter;
 import openfl.geom.ColorTransform;
 #if hscript
 import hscript.Interp;
@@ -491,6 +493,12 @@ class AnimateTimeline extends Timeline
 
 					case GlowFilter(color, alpha, blurX, blurY, strength, quality, inner, knockout):
 						filters.push(new GlowFilter(color, alpha, blurX, blurY, strength, quality, inner, knockout));
+
+					case GradientGlowFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						filters.push(new GradientGlowFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout));
+
+					case GradientBevelFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						filters.push(new GradientBevelFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout));
 				}
 			}
 

--- a/src/swf/exporters/core/FilterType.hx
+++ b/src/swf/exporters/core/FilterType.hx
@@ -7,4 +7,8 @@ enum FilterType
 	DropShadowFilter(distance:Float, angle:Float, color:Int, alpha:Float, blurX:Float, blurY:Float, strength:Float, quality:Int, inner:Bool, knockout:Bool,
 		hideObject:Bool);
 	GlowFilter(color:Int, alpha:Float, blurX:Float, blurY:Float, strength:Float, quality:Int, inner:Bool, knockout:Bool);
+	GradientGlowFilter(distance:Float, angle:Float, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, blurX:Float, blurY:Float, strength:Float,
+		quality:Int, type:String, knockout:Bool);
+	GradientBevelFilter(distance:Float, angle:Float, colors:Array<Int>, alphas:Array<Float>, ratios:Array<Int>, blurX:Float, blurY:Float, strength:Float,
+		quality:Int, type:String, knockout:Bool);
 }

--- a/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
+++ b/src/swf/exporters/swflite/timeline/SymbolTimeline.hx
@@ -28,6 +28,8 @@ import openfl.filters.ConvolutionFilter;
 import openfl.filters.DisplacementMapFilter;
 import openfl.filters.DropShadowFilter;
 import openfl.filters.GlowFilter;
+import openfl.filters.GradientGlowFilter;
+import openfl.filters.GradientBevelFilter;
 import openfl.geom.ColorTransform;
 #if hscript
 import hscript.Interp;
@@ -463,6 +465,12 @@ class SymbolTimeline extends Timeline
 
 					case GlowFilter(color, alpha, blurX, blurY, strength, quality, inner, knockout):
 						filters.push(new GlowFilter(color, alpha, blurX, blurY, strength, quality, inner, knockout));
+
+					case GradientGlowFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						filters.push(new GradientGlowFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout));
+
+					case GradientBevelFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout):
+						filters.push(new GradientBevelFilter(distance, angle, colors, alphas, ratios, blurX, blurY, strength, quality, type, knockout));
 				}
 			}
 


### PR DESCRIPTION
I have a PR for adding GradientGlow and GradientBevel  filters to openFL here : https://github.com/openfl/openfl/pull/2893
This PR  adds support for using SWF assets with these filters, but does require the openFL PR changes to work.

if its necessary i can probably wrap these new filters in conditional compilation require a specific openFL version, but i am not sure if this is nessesary or if you just say version X of SWF now requre version Y of  openFL.
